### PR TITLE
Add `Effect.none` & `Effect.cancel`

### DIFF
--- a/Sources/Harvest/Effect.swift
+++ b/Sources/Harvest/Effect.swift
@@ -2,21 +2,106 @@ import Combine
 
 /// Managed side-effect that enqueues `publisher` on `EffectQueue`
 /// to perform arbitrary `Queue.flattenStrategy`.
-public struct Effect<Input, Queue> where Queue: EffectQueueProtocol
+///
+/// This type also handles effect cancellation via `cancel`.
+public struct Effect<Input, Queue, ID>
+    where Queue: EffectQueueProtocol, ID: Equatable
 {
-    /// "Cold" stream that runs side-effect and sends next `Input`.
-    public let publisher: AnyPublisher<Input, Never>
+    internal let kind: Kind
 
-    /// Effect queue that associates with `publisher` to perform various `flattenStrategy`s.
-    internal let queue: EffectQueue<Queue>
+    internal init(kind: Kind)
+    {
+        self.kind = kind
+    }
 
-    /// - Parameter queue: Uses custom queue, or set `nil` as default queue to use `merge` strategy.
+    /// Managed side-effect that enqueues `publisher` on `EffectQueue`
+    /// to perform arbitrary `Queue.flattenStrategy`.
+    ///
+    /// - Parameters:
+    ///   - producer: "Cold" stream that runs side-effect and sends next `Input`.
+    ///   - queue: Uses custom queue, or set `nil` as default queue to use `merge` strategy.
+    ///   - id: Effect identifier for cancelling running `producer`.
     public init(
         _ publisher: AnyPublisher<Input, Never>,
-        queue: Queue? = nil
+        queue: Queue? = nil,
+        id: ID? = nil
         )
     {
-        self.publisher = publisher
-        self.queue = queue.map(EffectQueue.custom) ?? .default
+        self.init(kind: .publisher(
+            Publisher(
+                publisher: publisher,
+                queue: queue.map(EffectQueue.custom) ?? .default,
+                id: id
+            )
+        ))
+    }
+
+    /// Cancels running `publisher` by specifying `identifiers`.
+    public static func cancel(
+        _ identifiers: @escaping (ID) -> Bool
+        ) -> Effect<Input, Queue, ID>
+    {
+        return Effect(kind: .cancel(identifiers))
+    }
+
+    /// Cancels running `publisher` by specifying `identifier`.
+    public static func cancel(
+        _ identifier: ID
+        ) -> Effect<Input, Queue, ID>
+    {
+        return Effect(kind: .cancel { $0 == identifier })
+    }
+
+    /// Empty side-effect.
+    public static var none: Effect<Input, Queue, ID>
+    {
+        return Effect(.empty)
+    }
+}
+
+extension Effect: ExpressibleByNilLiteral
+{
+    public init(nilLiteral: ())
+    {
+        self = .none
+    }
+}
+
+extension Effect
+{
+    internal var publisher: Publisher?
+    {
+        guard case let .publisher(value) = self.kind else { return nil }
+        return value
+    }
+
+    internal var cancel: ((ID) -> Bool)?
+    {
+        guard case let .cancel(value) = self.kind else { return nil }
+        return value
+    }
+}
+
+
+// MARK: - Inner Types
+
+extension Effect
+{
+    internal enum Kind
+    {
+        case publisher(Publisher)
+        case cancel((ID) -> Bool)
+    }
+
+    internal struct Publisher
+    {
+        /// "Cold" stream that runs side-effect and sends next `Input`.
+        internal let publisher: AnyPublisher<Input, Never>
+
+        /// Effect queue that associates with `publisher` to perform various `flattenStrategy`s.
+        internal let queue: EffectQueue<Queue>
+
+        /// Effect identifier for cancelling running `publisher`.
+        internal let id: ID?
     }
 }

--- a/Sources/Harvest/Mapping+Helper.swift
+++ b/Sources/Harvest/Mapping+Helper.swift
@@ -79,18 +79,18 @@ public func | <State, Input: Equatable>(
 
 // MARK: `|` (Harvester.EffectMapping constructor)
 
-public func | <State, Input>(
+public func | <State, Input, Queue, EffectID>(
     mapping: @escaping Harvester<State, Input>.Mapping,
     effect: AnyPublisher<Input, Never>
-    ) -> Harvester<State, Input>.EffectMapping<Never>
+    ) -> Harvester<State, Input>.EffectMapping<Queue, EffectID>
 {
     return mapping | Effect(effect)
 }
 
-public func | <State, Input, Queue>(
+public func | <State, Input, Queue, EffectID>(
     mapping: @escaping Harvester<State, Input>.Mapping,
-    effect: Effect<Input, Queue>?
-    ) -> Harvester<State, Input>.EffectMapping<Queue>
+    effect: Effect<Input, Queue, EffectID>
+    ) -> Harvester<State, Input>.EffectMapping<Queue, EffectID>
 {
     return { fromState, input in
         if let toState = mapping(fromState, input) {
@@ -127,10 +127,10 @@ public func reduce<State, Input, Mappings: Sequence>(_ mappings: Mappings) -> Ha
 }
 
 /// Folds multiple `Harvester.EffectMapping`s into one (preceding mapping has higher priority).
-public func reduce<State, Input, Mappings: Sequence, Queue>(
+public func reduce<State, Input, Mappings: Sequence, Queue, EffectID>(
     _ mappings: Mappings
-    ) -> Harvester<State, Input>.EffectMapping<Queue>
-    where Mappings.Iterator.Element == Harvester<State, Input>.EffectMapping<Queue>
+    ) -> Harvester<State, Input>.EffectMapping<Queue, EffectID>
+    where Mappings.Iterator.Element == Harvester<State, Input>.EffectMapping<Queue, EffectID>
 {
     return { fromState, input in
         for mapping in mappings {

--- a/Tests/HarvestTests/EffectMappingLatestSpec.swift
+++ b/Tests/HarvestTests/EffectMappingLatestSpec.swift
@@ -9,7 +9,7 @@ class EffectMappingLatestSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<AuthState, AuthInput>
-        typealias EffectMapping = Harvester.EffectMapping<Queue>
+        typealias EffectMapping = Harvester.EffectMapping<Queue, Never>
 
         let inputs = PassthroughSubject<AuthInput, Never>()
         var harvester: Harvester?

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -9,7 +9,7 @@ class EffectMappingSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<AuthState, AuthInput>
-        typealias EffectMapping = Harvester.EffectMapping<Never>
+        typealias EffectMapping = Harvester.EffectMapping<Never, Never>
 
         let inputs = PassthroughSubject<AuthInput, Never>()
         var harvester: Harvester!

--- a/Tests/HarvestTests/StateFuncMappingSpec.swift
+++ b/Tests/HarvestTests/StateFuncMappingSpec.swift
@@ -11,7 +11,7 @@ class StateFuncMappingSpec: QuickSpec
         describe("State-change function mapping") {
 
             typealias Harvester = Harvest.Harvester<CountState, CountInput>
-            typealias EffectMapping = Harvester.EffectMapping<Never>
+            typealias EffectMapping = Harvester.EffectMapping<Never, Never>
 
             let inputs = PassthroughSubject<CountInput, Never>()
             var harvester: Harvester!

--- a/Tests/HarvestTests/TerminatingSpec.swift
+++ b/Tests/HarvestTests/TerminatingSpec.swift
@@ -8,7 +8,7 @@ class TerminatingSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<MyState, MyInput>
-        typealias EffectMapping = Harvester.EffectMapping<Never>
+        typealias EffectMapping = Harvester.EffectMapping<Never, Never>
 
         var harvester: Harvester!
         var lastReply: Reply<MyState, MyInput>?


### PR DESCRIPTION
This PR applies following `Effect` improvements from [ReactiveAutomaton](https://github.com/inamiy/ReactiveAutomaton) .

- https://github.com/inamiy/ReactiveAutomaton/pull/15
  Add `Effect.none` and conform to `ExpressibleByNilLiteral`
- https://github.com/inamiy/ReactiveAutomaton/pull/16
  Add `EffectID`-based `Effect.cancel`