### PR TITLE
Reverse input-state param order

### DIFF
--- a/Sources/Harvest/Harvester+Feedback.swift
+++ b/Sources/Harvest/Harvester+Feedback.swift
@@ -13,7 +13,7 @@ extension Harvester
         state initialState: State,
         inputs inputSignal: Inputs,
         mapping: @escaping Mapping,
-        feedback: Feedback<Reply<State, Input>.Success, Input>
+        feedback: Feedback<Reply<Input, State>.Success, Input>
         )
         where Inputs.Output == Input, Inputs.Failure == Never
     {
@@ -23,11 +23,11 @@ extension Harvester
             makeSignals: { from -> MakeSignals in
                 let mapped = from
                     .map { input, fromState in
-                        return (input, fromState, mapping(fromState, input))
+                        return (input, fromState, mapping(input, fromState))
                     }
 
                 let replies = mapped
-                    .map { input, fromState, mapped -> Reply<State, Input> in
+                    .map { input, fromState, mapped -> Reply<Input, State> in
                         if let toState = mapped {
                             return .success((input, fromState, toState))
                         }

--- a/Sources/Harvest/Reply.swift
+++ b/Sources/Harvest/Reply.swift
@@ -1,5 +1,5 @@
 /// `Harvester`'s reply to state transition.
-public enum Reply<State, Input>
+public enum Reply<Input, State>
 {
     /// Transition success, i.e. `(input, fromState, toState)`.
     case success(Success)

--- a/Tests/HarvestTests/AnyMappingSpec.swift
+++ b/Tests/HarvestTests/AnyMappingSpec.swift
@@ -8,11 +8,11 @@ class AnyMappingSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Harvester = Harvest.Harvester<MyState, MyInput>
+        typealias Harvester = Harvest.Harvester<MyInput, MyState>
 
         let inputs = PassthroughSubject<MyInput, Never>()
         var harvester: Harvester!
-        var lastReply: Reply<MyState, MyInput>?
+        var lastReply: Reply<MyInput, MyState>?
 
         describe("`anyState`/`anyInput` mapping") {
 

--- a/Tests/HarvestTests/EffectMappingLatestSpec.swift
+++ b/Tests/HarvestTests/EffectMappingLatestSpec.swift
@@ -8,12 +8,12 @@ class EffectMappingLatestSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Harvester = Harvest.Harvester<AuthState, AuthInput>
+        typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
         typealias EffectMapping = Harvester.EffectMapping<Queue, Never>
 
         let inputs = PassthroughSubject<AuthInput, Never>()
         var harvester: Harvester?
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
 
         describe("strategy = `.latest`") {
 

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -3,17 +3,17 @@ import Harvest
 import Quick
 import Nimble
 
-/// Tests for `(State, Input) -> (State, Effect?)?` mapping.
+/// Tests for `(Input, State) -> (State, Effect?)?` mapping.
 class EffectMappingSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Harvester = Harvest.Harvester<AuthState, AuthInput>
+        typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
         typealias EffectMapping = Harvester.EffectMapping<Never, Never>
 
         let inputs = PassthroughSubject<AuthInput, Never>()
         var harvester: Harvester!
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
         var testScheduler: TestScheduler!
 
         describe("Syntax-sugar EffectMapping") {
@@ -105,7 +105,7 @@ class EffectMappingSpec: QuickSpec
                         .delay(for: 1, scheduler: testScheduler)
                         .eraseToAnyPublisher()
 
-                let mapping: EffectMapping = { fromState, input in
+                let mapping: EffectMapping = { input, fromState in
                     switch (fromState, input) {
                         case (.loggedOut, .login):
                             return (.loggingIn, .init(loginOKPublisher))

--- a/Tests/HarvestTests/FeedbackSpec.swift
+++ b/Tests/HarvestTests/FeedbackSpec.swift
@@ -7,13 +7,13 @@ class FeedbackSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Harvester = Harvest.Harvester<AuthState, AuthInput>
+        typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
         typealias Mapping = Harvester.Mapping
-        typealias Feedback = Harvest.Feedback<Reply<AuthState, AuthInput>.Success, AuthInput>
+        typealias Feedback = Harvest.Feedback<Reply<AuthInput, AuthState>.Success, AuthInput>
 
         let inputs = PassthroughSubject<AuthInput, Never>()
         var harvester: Harvester?
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
         var testScheduler: TestScheduler!
 
         describe("Feedback") {

--- a/Tests/HarvestTests/MappingSpec.swift
+++ b/Tests/HarvestTests/MappingSpec.swift
@@ -3,17 +3,17 @@ import Harvest
 import Quick
 import Nimble
 
-/// Tests for `(State, Input) -> State?` mapping.
+/// Tests for `(Input, State) -> State?` mapping.
 class MappingSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Harvester = Harvest.Harvester<AuthState, AuthInput>
+        typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
         typealias Mapping = Harvester.Mapping
 
         let inputs = PassthroughSubject<AuthInput, Never>()
         var harvester: Harvester!
-        var lastReply: Reply<AuthState, AuthInput>?
+        var lastReply: Reply<AuthInput, AuthState>?
 
         describe("Syntax-sugar Mapping") {
 
@@ -120,7 +120,7 @@ class MappingSpec: QuickSpec
         describe("Func-based Mapping") {
 
             beforeEach {
-                let mapping: Mapping = { fromState, input in
+                let mapping: Mapping = { input, fromState in
                     switch (fromState, input) {
                         case (.loggedOut, .login):
                             return .loggingIn

--- a/Tests/HarvestTests/StateFuncMappingSpec.swift
+++ b/Tests/HarvestTests/StateFuncMappingSpec.swift
@@ -10,7 +10,7 @@ class StateFuncMappingSpec: QuickSpec
     {
         describe("State-change function mapping") {
 
-            typealias Harvester = Harvest.Harvester<CountState, CountInput>
+            typealias Harvester = Harvest.Harvester<CountInput, CountState>
             typealias EffectMapping = Harvester.EffectMapping<Never, Never>
 
             let inputs = PassthroughSubject<CountInput, Never>()

--- a/Tests/HarvestTests/TerminatingSpec.swift
+++ b/Tests/HarvestTests/TerminatingSpec.swift
@@ -7,11 +7,11 @@ class TerminatingSpec: QuickSpec
 {
     override func spec()
     {
-        typealias Harvester = Harvest.Harvester<MyState, MyInput>
+        typealias Harvester = Harvest.Harvester<MyInput, MyState>
         typealias EffectMapping = Harvester.EffectMapping<Never, Never>
 
         var harvester: Harvester!
-        var lastReply: Reply<MyState, MyInput>?
+        var lastReply: Reply<MyInput, MyState>?
         var lastRepliesCompletion: Subscribers.Completion<Never>?
 
         /// Flag for internal effect `sendInput1And2AfterDelay` disposed.


### PR DESCRIPTION
This PR applies https://github.com/inamiy/ReactiveAutomaton/pull/14 , reversing `State` and `Input` generic type parameter.

```diff
-public final class Harvester<State, Input>
+public final class Harvester<Input, State>
```