### PR TITLE
Add `BasicEffectQueue` to simplify code

### DIFF
--- a/Sources/Harvest/Effect.swift
+++ b/Sources/Harvest/Effect.swift
@@ -23,14 +23,14 @@ public struct Effect<Input, Queue, ID>
     ///   - id: Effect identifier for cancelling running `producer`.
     public init(
         _ publisher: AnyPublisher<Input, Never>,
-        queue: Queue? = nil,
+        queue: Queue = .defaultEffectQueue,
         id: ID? = nil
         )
     {
         self.init(kind: .publisher(
             _Publisher(
                 publisher: publisher,
-                queue: queue.map(EffectQueue.custom) ?? .default,
+                queue: queue,
                 id: id
             )
         ))
@@ -115,7 +115,7 @@ extension Effect
         internal let publisher: AnyPublisher<Input, Never>
 
         /// Effect queue that associates with `publisher` to perform various `flattenStrategy`s.
-        internal let queue: EffectQueue<Queue>
+        internal let queue: Queue
 
         /// Effect identifier for cancelling running `publisher`.
         internal let id: ID?

--- a/Sources/Harvest/Harvester.swift
+++ b/Sources/Harvest/Harvester.swift
@@ -24,7 +24,7 @@ public final class Harvester<Input, State>
         self.init(
             state: initialState,
             inputs: inputSignal,
-            mapping: { mapping($0, $1).map { ($0, Effect<Input, Never, Never>.none) } }
+            mapping: { mapping($0, $1).map { ($0, Effect<Input, BasicEffectQueue, Never>.none) } }
         )
     }
 
@@ -75,7 +75,7 @@ public final class Harvester<Input, State>
                 let cancels = effects.compactMap { $0.cancel }
 
                 let effectInputs = Publishers.MergeMany(
-                    EffectQueue<Queue>.allCases.map { queue in
+                    Queue.allCases.map { queue in
                         publishers
                             .filter { $0.queue == queue }
                             .flatMap(queue.flattenStrategy) { publisher -> AnyPublisher<Input, Never> in

--- a/Tests/HarvestTests/EffectMappingLatestSpec.swift
+++ b/Tests/HarvestTests/EffectMappingLatestSpec.swift
@@ -10,7 +10,7 @@ class EffectMappingLatestSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
-        typealias EffectMapping = Harvester.EffectMapping<Queue, Never>
+        typealias EffectMapping = Harvester.EffectMapping<EffectQueue, Never>
 
         var inputs: PassthroughSubject<AuthInput, Never>!
         var harvester: Harvester!
@@ -93,12 +93,21 @@ class EffectMappingLatestSpec: QuickSpec
 
 // MARK: - Private
 
-private enum Queue: EffectQueueProtocol
+private enum EffectQueue: EffectQueueProtocol
 {
+    case `default`
     case request
 
     var flattenStrategy: FlattenStrategy
     {
-        return .latest
+        switch self {
+        case .default: return .merge
+        case .request: return .latest
+        }
+    }
+
+    static var defaultEffectQueue: EffectQueue
+    {
+        .default
     }
 }

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -10,7 +10,7 @@ class EffectMappingSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
-        typealias EffectMapping = Harvester.EffectMapping<Never, Never>
+        typealias EffectMapping = Harvester.EffectMapping<BasicEffectQueue, Never>
 
         var inputs: PassthroughSubject<AuthInput, Never>!
         var harvester: Harvester!

--- a/Tests/HarvestTests/Fixtures/Fixtures.swift
+++ b/Tests/HarvestTests/Fixtures/Fixtures.swift
@@ -50,35 +50,3 @@ enum MyInput
 {
     case input0, input1, input2
 }
-
-// MARK: - Workarounds
-
-// Dummy test scheduler for letting compile work.
-//typealias TestScheduler = ImmediateScheduler
-//
-//extension TestScheduler
-//{
-//    init()
-//    {
-//        self = TestScheduler.shared
-//    }
-//
-//    func advanceByInterval(_ t: Double)
-//    {
-//        // do nothing
-//    }
-//}
-
-extension Subscribers.Completion: Equatable where Failure: Equatable
-{
-    public static func == (lhs: Subscribers.Completion<Failure>, rhs: Subscribers.Completion<Failure>) -> Bool {
-        switch (lhs, rhs) {
-        case (.finished, .finished):
-            return true
-        case let (.failure(l), .failure(r)):
-            return l == r
-        default:
-            return false
-        }
-    }
-}

--- a/Tests/HarvestTests/StateFuncMappingSpec.swift
+++ b/Tests/HarvestTests/StateFuncMappingSpec.swift
@@ -11,7 +11,7 @@ class StateFuncMappingSpec: QuickSpec
         describe("State-change function mapping") {
 
             typealias Harvester = Harvest.Harvester<CountInput, CountState>
-            typealias EffectMapping = Harvester.EffectMapping<Never, Never>
+            typealias EffectMapping = Harvester.EffectMapping<BasicEffectQueue, Never>
 
             var inputs: PassthroughSubject<CountInput, Never>!
             var harvester: Harvester!

--- a/Tests/HarvestTests/TerminatingSpec.swift
+++ b/Tests/HarvestTests/TerminatingSpec.swift
@@ -9,7 +9,7 @@ class TerminatingSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<MyInput, MyState>
-        typealias EffectMapping = Harvester.EffectMapping<Never, Never>
+        typealias EffectMapping = Harvester.EffectMapping<BasicEffectQueue, Never>
 
         var inputs: PassthroughSubject<MyInput, Never>!
         var harvester: Harvester!


### PR DESCRIPTION
Breaking down internal `EffectQueue<Queue: EffectQueueProtocol>` to just **use `Queue` with having `BasicEffectQueue` built-in type** will simplify the overall code and readability, which also removes the bad usage of `Never` and `nil`.