### PR TITLE
Add HarvestStore & HarvestOptics

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/inamiy/FunOptics",
         "state": {
           "branch": null,
-          "revision": "02022bcd4b6e77b03f34af672c3815d65ffd23d7",
-          "version": "1.0.0"
+          "revision": "d11d509d998f629a09ab1b627e31000a20c9c308",
+          "version": "1.0.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "FunOptics",
+        "repositoryURL": "https://github.com/inamiy/FunOptics",
+        "state": {
+          "branch": null,
+          "revision": "02022bcd4b6e77b03f34af672c3815d65ffd23d7",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             targets: ["HarvestOptics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/inamiy/FunOptics", from: "1.0.0"),
+        .package(url: "https://github.com/inamiy/FunOptics", from: "1.0.1"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,14 +12,30 @@ let package = Package(
         .library(
             name: "Harvest",
             targets: ["Harvest"]),
+
+        .library(
+            name: "HarvestStore",
+            targets: ["HarvestStore"]),
+
+        .library(
+            name: "HarvestOptics",
+            targets: ["HarvestOptics"]),
     ],
-    dependencies:  [
+    dependencies: [
+        .package(url: "https://github.com/inamiy/FunOptics", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "Harvest",
-            dependencies: [],
-            path: "Sources"),
+            dependencies: []),
+
+        .target(
+            name: "HarvestStore",
+            dependencies: ["Harvest"]),
+
+        .target(
+            name: "HarvestOptics",
+            dependencies: ["Harvest", "FunOptics"]),
     ]
 )
 

--- a/Sources/Harvest/Harvester+Feedback.swift
+++ b/Sources/Harvest/Harvester+Feedback.swift
@@ -9,7 +9,7 @@ extension Harvester
     ///   - input: External "hot" input stream that `Harvester` receives.
     ///   - mapping: Simple `Mapping` that designates next state only (no additional effect).
     ///   - feedback: `Publisher` transformer that performs side-effect and emits next input.
-    ///   - scheduler: Scheduler for next inputs from `Feedback`.
+    ///   - scheduler: Scheduler for `inputs` and next inputs from `Feedback`.
     ///   - options: `scheduler` options.
     public convenience init<Inputs: Publisher, S: Scheduler>(
         state initialState: State,

--- a/Sources/Harvest/Harvester.swift
+++ b/Sources/Harvest/Harvester.swift
@@ -4,6 +4,7 @@ import Combine
 /// and with "current state" transform to "next state" & "output (additional effect)".
 public final class Harvester<Input, State>
 {
+    /// Current state.
     @Published
     public private(set) var state: State
 

--- a/Sources/HarvestOptics/EffectMapping+Optics.swift
+++ b/Sources/HarvestOptics/EffectMapping+Optics.swift
@@ -1,0 +1,56 @@
+import FunOptics
+import Harvest
+
+/// Lifts `EffectMapping` from `PartInput` to `WholeInput`.
+public func lift<WholeInput, PartInput, State, Queue, EffectID>(
+    input inputTraversal: AffineTraversal<WholeInput, PartInput>
+)
+    -> (_ mapping: @escaping Harvester<PartInput, State>.EffectMapping<Queue, EffectID>)
+    -> Harvester<WholeInput, State>.EffectMapping<Queue, EffectID>
+{
+    return { mapping in
+        return { wholeInput, state in
+            guard let partInput = inputTraversal.tryGet(wholeInput),
+                let (newState, effect) = mapping(partInput, state) else
+            {
+                return nil
+            }
+            return (newState, effect.mapInput { inputTraversal.set(wholeInput, $0) })
+        }
+    }
+}
+
+/// Lifts `EffectMapping` from `PartState` to `WholeState`.
+public func lift<WholeState, PartState, Input, Queue, EffectID>(
+    state stateTraversal: AffineTraversal<WholeState, PartState>
+)
+    -> (_ mapping: @escaping Harvester<Input, PartState>.EffectMapping<Queue, EffectID>)
+    -> Harvester<Input, WholeState>.EffectMapping<Queue, EffectID>
+{
+    return { mapping in
+        return { input, wholeState in
+            guard let partState = stateTraversal.tryGet(wholeState),
+                let (newPartState, effect) = mapping(input, partState) else
+            {
+                return nil
+            }
+
+            let newWholeState = stateTraversal.set(wholeState, newPartState)
+
+            return (newWholeState, effect)
+        }
+    }
+}
+
+/// Lifts `EffectMapping` from `<PartInput, PartState>` to `<WholeInput, WholeState>`.
+public func lift<WholeInput, PartInput, WholeState, PartState, Queue, EffectID>(
+    input inputTraversal: AffineTraversal<WholeInput, PartInput>,
+    state stateTraversal: AffineTraversal<WholeState, PartState>
+)
+    -> (_ mapping: @escaping Harvester<PartInput, PartState>.EffectMapping<Queue, EffectID>)
+    -> Harvester<WholeInput, WholeState>.EffectMapping<Queue, EffectID>
+{
+    return { mapping in
+        lift(state: stateTraversal)(lift(input: inputTraversal)(mapping))
+    }
+}

--- a/Sources/HarvestOptics/EffectMapping+Optics.swift
+++ b/Sources/HarvestOptics/EffectMapping+Optics.swift
@@ -5,13 +5,13 @@ import Harvest
 public func lift<WholeInput, PartInput, State, Queue, EffectID>(
     input inputTraversal: AffineTraversal<WholeInput, PartInput>
 )
-    -> (_ mapping: @escaping Harvester<PartInput, State>.EffectMapping<Queue, EffectID>)
+    -> (_ mapping: Harvester<PartInput, State>.EffectMapping<Queue, EffectID>)
     -> Harvester<WholeInput, State>.EffectMapping<Queue, EffectID>
 {
     return { mapping in
-        return { wholeInput, state in
+        return .init { wholeInput, state in
             guard let partInput = inputTraversal.tryGet(wholeInput),
-                let (newState, effect) = mapping(partInput, state) else
+                let (newState, effect) = mapping.run(partInput, state) else
             {
                 return nil
             }
@@ -24,13 +24,13 @@ public func lift<WholeInput, PartInput, State, Queue, EffectID>(
 public func lift<WholeState, PartState, Input, Queue, EffectID>(
     state stateTraversal: AffineTraversal<WholeState, PartState>
 )
-    -> (_ mapping: @escaping Harvester<Input, PartState>.EffectMapping<Queue, EffectID>)
+    -> (_ mapping: Harvester<Input, PartState>.EffectMapping<Queue, EffectID>)
     -> Harvester<Input, WholeState>.EffectMapping<Queue, EffectID>
 {
     return { mapping in
-        return { input, wholeState in
+        return .init { input, wholeState in
             guard let partState = stateTraversal.tryGet(wholeState),
-                let (newPartState, effect) = mapping(input, partState) else
+                let (newPartState, effect) = mapping.run(input, partState) else
             {
                 return nil
             }
@@ -47,7 +47,7 @@ public func lift<WholeInput, PartInput, WholeState, PartState, Queue, EffectID>(
     input inputTraversal: AffineTraversal<WholeInput, PartInput>,
     state stateTraversal: AffineTraversal<WholeState, PartState>
 )
-    -> (_ mapping: @escaping Harvester<PartInput, PartState>.EffectMapping<Queue, EffectID>)
+    -> (_ mapping: Harvester<PartInput, PartState>.EffectMapping<Queue, EffectID>)
     -> Harvester<WholeInput, WholeState>.EffectMapping<Queue, EffectID>
 {
     return { mapping in

--- a/Sources/HarvestOptics/EffectMapping+Optics.swift
+++ b/Sources/HarvestOptics/EffectMapping+Optics.swift
@@ -1,36 +1,31 @@
 import FunOptics
 import Harvest
 
-/// Lifts `EffectMapping` from `PartInput` to `WholeInput`.
-public func lift<WholeInput, PartInput, State, Queue, EffectID>(
-    input inputTraversal: AffineTraversal<WholeInput, PartInput>
-)
-    -> (_ mapping: Harvester<PartInput, State>.EffectMapping<Queue, EffectID>)
-    -> Harvester<WholeInput, State>.EffectMapping<Queue, EffectID>
+extension Harvester.EffectMapping
 {
-    return { mapping in
+    /// Transforms `EffectMapping` from `Input` to `WholeInput`.
+    public func transform<WholeInput>(
+        input inputTraversal: AffineTraversal<WholeInput, Input>
+    ) -> Harvester<WholeInput, State>.EffectMapping<Queue, EffectID>
+    {
         return .init { wholeInput, state in
             guard let partInput = inputTraversal.tryGet(wholeInput),
-                let (newState, effect) = mapping.run(partInput, state) else
+                let (newState, effect) = self.run(partInput, state) else
             {
                 return nil
             }
             return (newState, effect.mapInput { inputTraversal.set(wholeInput, $0) })
         }
     }
-}
 
-/// Lifts `EffectMapping` from `PartState` to `WholeState`.
-public func lift<WholeState, PartState, Input, Queue, EffectID>(
-    state stateTraversal: AffineTraversal<WholeState, PartState>
-)
-    -> (_ mapping: Harvester<Input, PartState>.EffectMapping<Queue, EffectID>)
-    -> Harvester<Input, WholeState>.EffectMapping<Queue, EffectID>
-{
-    return { mapping in
+    /// Transforms `EffectMapping` from `State` to `WholeState`.
+    public func transform<WholeState>(
+        state stateTraversal: AffineTraversal<WholeState, State>
+    ) -> Harvester<Input, WholeState>.EffectMapping<Queue, EffectID>
+    {
         return .init { input, wholeState in
             guard let partState = stateTraversal.tryGet(wholeState),
-                let (newPartState, effect) = mapping.run(input, partState) else
+                let (newPartState, effect) = self.run(input, partState) else
             {
                 return nil
             }
@@ -40,17 +35,5 @@ public func lift<WholeState, PartState, Input, Queue, EffectID>(
             return (newWholeState, effect)
         }
     }
-}
 
-/// Lifts `EffectMapping` from `<PartInput, PartState>` to `<WholeInput, WholeState>`.
-public func lift<WholeInput, PartInput, WholeState, PartState, Queue, EffectID>(
-    input inputTraversal: AffineTraversal<WholeInput, PartInput>,
-    state stateTraversal: AffineTraversal<WholeState, PartState>
-)
-    -> (_ mapping: Harvester<PartInput, PartState>.EffectMapping<Queue, EffectID>)
-    -> Harvester<WholeInput, WholeState>.EffectMapping<Queue, EffectID>
-{
-    return { mapping in
-        lift(state: stateTraversal)(lift(input: inputTraversal)(mapping))
-    }
 }

--- a/Sources/HarvestStore/Binding+Helper.swift
+++ b/Sources/HarvestStore/Binding+Helper.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+extension Binding
+{
+    /// Transforms `<Value>` to `<SubValue>` using `get` and `set` invariant mappers.
+    public func invmap<SubValue>(
+        get: @escaping (Value) -> SubValue,
+        set: @escaping (SubValue) -> Value
+    ) -> Binding<SubValue>
+    {
+        Binding<SubValue>(
+            get: { get(self.wrappedValue) },
+            set: { self.wrappedValue = set($0) }
+        )
+    }
+
+    /// Transforms `<Value>` to `<SubValue>` using `WritableKeyPath`.
+    ///
+    /// - Note:
+    ///   This is almost the same as `subscript(dynamicMember:)` provided by SwiftUI,
+    ///   but this implementation can avoid internal `SwiftUI.BindingOperations.ForceUnwrapping` failure crash.
+    public subscript<SubValue>(_ keyPath: WritableKeyPath<Value, SubValue>)
+        -> Binding<SubValue>
+    {
+        Binding<SubValue>(
+            get: { self.wrappedValue[keyPath: keyPath] },
+            set: { self.wrappedValue[keyPath: keyPath] = $0 }
+        )
+    }
+}

--- a/Sources/HarvestStore/Store.Proxy.swift
+++ b/Sources/HarvestStore/Store.Proxy.swift
@@ -11,6 +11,12 @@ extension Store
 
         public let send: (Input) -> Void
 
+        public init(state: Binding<State>, send: @escaping (Input) -> Void)
+        {
+            self._state = state
+            self.send = send
+        }
+
         /// Transforms `<Input, State>` to `<Input, SubState>` using keyPath `@dynamicMemberLookup`.
         public subscript<SubState>(
             dynamicMember keyPath: WritableKeyPath<State, SubState>

--- a/Sources/HarvestStore/Store.Proxy.swift
+++ b/Sources/HarvestStore/Store.Proxy.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+extension Store
+{
+    /// Lightweight `Store` proxy that is state-bindable and input-sendable without duplicating internal state.
+    @dynamicMemberLookup
+    public struct Proxy
+    {
+        @Binding
+        public private(set) var state: State
+
+        public let send: (Input) -> Void
+
+        /// Transforms `<Input, State>` to `<Input, SubState>` using keyPath `@dynamicMemberLookup`.
+        public subscript<SubState>(
+            dynamicMember keyPath: WritableKeyPath<State, SubState>
+        ) -> Store<Input, SubState>.Proxy
+        {
+            .init(state: self.$state[dynamicMember: keyPath], send: self.send)
+        }
+
+        /// Indirect state-to-input conversion binding to create `Binding<State>`.
+        public func stateBinding(
+            onChange: @escaping (State) -> Input?
+        ) -> Binding<State>
+        {
+            self.stateBinding(get: { $0 }, onChange: onChange)
+        }
+
+        /// Indirect state-to-input conversion binding to create `Binding<SubState>`.
+        public func stateBinding<SubState>(
+            get: @escaping (State) -> SubState,
+            onChange: @escaping (SubState) -> Input?
+        ) -> Binding<SubState>
+        {
+            Binding<SubState>(
+                get: {
+                    get(self.state)
+                },
+                set: {
+                    if let input = onChange($0) {
+                        self.send(input)
+                    }
+                }
+            )
+        }
+    }
+}

--- a/Sources/HarvestStore/Store.swift
+++ b/Sources/HarvestStore/Store.swift
@@ -1,0 +1,110 @@
+import Foundation
+import SwiftUI
+import Combine
+import Harvest
+
+/// Store of `Harvester` optimized for SwiftUI's 2-way binding.
+public final class Store<Input, State>: ObservableObject
+{
+    private let harvester: Harvester<BindableInput, State>
+
+    private let inputs = PassthroughSubject<BindableInput, Never>()
+
+    private var cancellable = Set<AnyCancellable>()
+
+    public init<Queue: EffectQueueProtocol, EffectID>(
+        state initialState: State,
+        effect initialEffect: Effect<Input, Queue, EffectID> = .none,
+        mapping: @escaping Harvester<Input, State>.EffectMapping<Queue, EffectID>
+    )
+    {
+        harvester = Harvester(
+            state: initialState,
+            effect: initialEffect.mapInput(Store<Input, State>.BindableInput.input),
+            inputs: inputs,
+            mapping: lift(effectMapping: mapping)
+        )
+    }
+
+    /// Current state.
+    public var state: State
+    {
+        self.harvester.state
+    }
+
+    /// Sends input.
+    public func send(_ input: Input)
+    {
+        self.inputs.send(.input(input))
+    }
+
+    /// Direct state binding.
+    public var binding: Binding<State>
+    {
+        return Binding<State>(
+            get: {
+                self.harvester.state
+            },
+            set: {
+                self.inputs.send(.state($0))
+            }
+        )
+    }
+
+    /// Indirect state-to-input conversion binding.
+    public func binding(to toInput: @escaping (State) -> Input) -> Binding<State>
+    {
+        return Binding<State>(
+            get: {
+                self.harvester.state
+            },
+            set: {
+                self.inputs.send(.input(toInput($0)))
+            }
+        )
+    }
+
+    public var objectWillChange: Published<State>.Publisher
+    {
+        self.harvester.$state
+    }
+}
+
+// MARK: - Store.BindableInput
+
+extension Store
+{
+    /// `input` as indirect messaging, or `state` that can directly replace `harvester.state` via SwiftUI 2-way binding.
+    public enum BindableInput
+    {
+        case input(Input)
+        case state(State)
+    }
+}
+
+// MARK: - Private
+
+extension Store
+{
+    fileprivate typealias EffectMapping<Queue, EffectID> = (BindableInput, State) -> (State, Effect<BindableInput, Queue, EffectID>)?
+        where Queue: EffectQueueProtocol, EffectID: Equatable
+}
+
+/// Lifts from `Harvester.EffectMapping` to `Store.EffectMapping`, converting from `Input` to `Store.BindableInput`.
+private func lift<Input, State, Queue: EffectQueueProtocol, EffectID>(
+    effectMapping: @escaping Harvester<Input, State>.EffectMapping<Queue, EffectID>
+) -> Store<Input, State>.EffectMapping<Queue, EffectID>
+{
+    { input, state in
+        switch input {
+        case let .input(innerInput):
+            guard let (newState, effect) = effectMapping(innerInput, state) else {
+                return nil
+            }
+            return (newState, effect.mapInput(Store<Input, State>.BindableInput.input))
+
+        case let .state(state):
+            return (state, nil)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds HarvestStore and HarvestOptics targets to enhance the composable architecturing, especially focused on SwiftUI.

- **HarvestStore**: 2-way bindable `Store` optimized for SwiftUI
- **HarvestOptics**: Input & state lifting helpers using [FunOptics](https://github.com/inamiy/FunOptics)

For Optics, please see https://github.com/Babylonpartners/ios-playbook/pull/171 for more detail. 