### PR TITLE
Fix multiple `mapping` calls by optimizing dataflow using `share`

### DIFF
--- a/Sources/Harvest/Harvester+Feedback.swift
+++ b/Sources/Harvest/Harvester+Feedback.swift
@@ -35,6 +35,7 @@ extension Harvester
                             return .failure((input, fromState))
                         }
                     }
+                    .share()
                     .eraseToAnyPublisher()
 
                 let effects = feedback.transform(replies.compactMap { $0.success }.eraseToAnyPublisher())

--- a/Sources/Harvest/Harvester.swift
+++ b/Sources/Harvest/Harvester.swift
@@ -53,6 +53,7 @@ public final class Harvester<Input, State>
                     .map { input, fromState in
                         return (input, fromState, mapping(input, fromState))
                     }
+                    .share()
 
                 let replies = mapped
                     .map { input, fromState, mapped -> Reply<Input, State> in
@@ -71,7 +72,7 @@ public final class Harvester<Input, State>
                         return effect
                     }
                     .prepend(initialEffect)
-                    .eraseToAnyPublisher()
+                    .share()
 
                 let publishers = effects.compactMap { $0.publisher }
                 let cancels = effects.compactMap { $0.cancel }
@@ -116,7 +117,6 @@ public final class Harvester<Input, State>
                 let fromState = self.state
                 return (input, fromState)
             }
-            .share()
             .eraseToAnyPublisher()
 
         let (replies, effects) = makeSignals(mapped)

--- a/Tests/HarvestTests/MappingCallCountSpec.swift
+++ b/Tests/HarvestTests/MappingCallCountSpec.swift
@@ -1,0 +1,68 @@
+import Combine
+import Harvest
+import Quick
+import Nimble
+
+/// Tests for `mapping` and `reply` call count.
+class MappingCallCountSpec: QuickSpec
+{
+    override func spec()
+    {
+        typealias Harvester = Harvest.Harvester<CountInput, CountState>
+        typealias Mapping = Harvester.Mapping
+
+        var inputs: PassthroughSubject<CountInput, Never>!
+        var harvester: Harvester!
+        var lastReply: Reply<CountInput, CountState>?
+        var cancellables: Set<AnyCancellable>!
+
+        var mappingCallCount = 0
+        var replyCallCount = 0
+
+        beforeEach {
+            inputs = PassthroughSubject()
+            lastReply = nil
+            cancellables = []
+        }
+
+        describe("Mapping & Reply call count") {
+
+            beforeEach {
+                mappingCallCount = 0
+
+                let mapping: Mapping = { input, state in
+                    mappingCallCount += 1
+
+                    switch input {
+                    case .increment: return state + 1
+                    case .decrement: return state - 1
+                    }
+                }
+
+                harvester = Harvester(state: 0, inputs: inputs, mapping: mapping)
+
+                harvester.replies
+                    .sink { reply in
+                        replyCallCount += 1
+                        lastReply = reply
+                    }
+                    .store(in: &cancellables)
+            }
+
+            it("should call `mapping` only once per input sent") {
+                expect(harvester.state) == 0
+                expect(lastReply).to(beNil())
+                expect(mappingCallCount) == 0
+                expect(replyCallCount) == 0
+
+                inputs.send(.increment)
+
+                expect(harvester.state) == 1
+                expect(lastReply?.input) == .increment
+                expect(mappingCallCount) == 1
+                expect(replyCallCount) == 1
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
`Mapping` was called multiple times per `Input` sent because of lack of `share()` optimization.
This PR fixes it.