### PR TITLE
Change `Mapping` & `EffectMapping` function types to struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ var cancellables: [AnyCancellable] = []
 let harvester = Harvester(
     state: .loggedOut,
     input: inputs,
-    mapping: reduce(mappings),  // combine mappings using `reduce` helper
+    mapping: .reduce(mappings),  // combine mappings using `reduce` helper
 )
 
 // Observe state-transition replies (`.success` or `.failure`).

--- a/Sources/Harvest/Harvester+Feedback.swift
+++ b/Sources/Harvest/Harvester+Feedback.swift
@@ -12,7 +12,7 @@ extension Harvester
     public convenience init<Inputs: Publisher>(
         state initialState: State,
         inputs inputSignal: Inputs,
-        mapping: @escaping Mapping,
+        mapping: Mapping,
         feedback: Feedback<Reply<Input, State>.Success, Input>
         )
         where Inputs.Output == Input, Inputs.Failure == Never
@@ -23,7 +23,7 @@ extension Harvester
             makeSignals: { from -> MakeSignals in
                 let mapped = from
                     .map { input, fromState in
-                        return (input, fromState, mapping(input, fromState))
+                        return (input, fromState, mapping.run(input, fromState))
                     }
 
                 let replies = mapped

--- a/Sources/Harvest/Mapping+Helper.swift
+++ b/Sources/Harvest/Mapping+Helper.swift
@@ -36,7 +36,7 @@ public func | <Input, State>(
     transition: Transition<State>
     ) -> Harvester<Input, State>.Mapping
 {
-    return { input, fromState in
+    return .init { input, fromState in
         if inputFunc(input) && transition.fromState(fromState) {
             return transition.toState
         }
@@ -59,7 +59,7 @@ public func | <Input, State>(
     transition: @escaping (State) -> State
     ) -> Harvester<Input, State>.Mapping
 {
-    return { input, fromState in
+    return .init { input, fromState in
         if inputFunc(input) {
             return transition(fromState)
         }
@@ -80,7 +80,7 @@ public func | <Input: Equatable, State>(
 // MARK: `|` (Harvester.EffectMapping constructor)
 
 public func | <Input, State, Queue, EffectID>(
-    mapping: @escaping Harvester<Input, State>.Mapping,
+    mapping: Harvester<Input, State>.Mapping,
     effect: AnyPublisher<Input, Never>
     ) -> Harvester<Input, State>.EffectMapping<Queue, EffectID>
 {
@@ -88,12 +88,12 @@ public func | <Input, State, Queue, EffectID>(
 }
 
 public func | <Input, State, Queue, EffectID>(
-    mapping: @escaping Harvester<Input, State>.Mapping,
+    mapping: Harvester<Input, State>.Mapping,
     effect: Effect<Input, Queue, EffectID>
     ) -> Harvester<Input, State>.EffectMapping<Queue, EffectID>
 {
-    return { input, fromState in
-        if let toState = mapping(input, fromState) {
+    return .init { input, fromState in
+        if let toState = mapping.run(input, fromState) {
             return (toState, effect)
         }
         else {
@@ -116,9 +116,9 @@ public func any<T>(_: T) -> Bool
 public func reduce<Input, State, Mappings: Sequence>(_ mappings: Mappings) -> Harvester<Input, State>.Mapping
     where Mappings.Iterator.Element == Harvester<Input, State>.Mapping
 {
-    return { input, fromState in
+    return .init { input, fromState in
         for mapping in mappings {
-            if let toState = mapping(input, fromState) {
+            if let toState = mapping.run(input, fromState) {
                 return toState
             }
         }
@@ -132,9 +132,9 @@ public func reduce<Input, State, Mappings: Sequence, Queue, EffectID>(
     ) -> Harvester<Input, State>.EffectMapping<Queue, EffectID>
     where Mappings.Iterator.Element == Harvester<Input, State>.EffectMapping<Queue, EffectID>
 {
-    return { input, fromState in
+    return .init { input, fromState in
         for mapping in mappings {
-            if let tuple = mapping(input, fromState) {
+            if let tuple = mapping.run(input, fromState) {
                 return tuple
             }
         }

--- a/Sources/Harvest/Mapping+Helper.swift
+++ b/Sources/Harvest/Mapping+Helper.swift
@@ -111,33 +111,3 @@ public func any<T>(_: T) -> Bool
 {
     return true
 }
-
-/// Folds multiple `Harvester.Mapping`s into one (preceding mapping has higher priority).
-public func reduce<Input, State, Mappings: Sequence>(_ mappings: Mappings) -> Harvester<Input, State>.Mapping
-    where Mappings.Iterator.Element == Harvester<Input, State>.Mapping
-{
-    return .init { input, fromState in
-        for mapping in mappings {
-            if let toState = mapping.run(input, fromState) {
-                return toState
-            }
-        }
-        return nil
-    }
-}
-
-/// Folds multiple `Harvester.EffectMapping`s into one (preceding mapping has higher priority).
-public func reduce<Input, State, Mappings: Sequence, Queue, EffectID>(
-    _ mappings: Mappings
-    ) -> Harvester<Input, State>.EffectMapping<Queue, EffectID>
-    where Mappings.Iterator.Element == Harvester<Input, State>.EffectMapping<Queue, EffectID>
-{
-    return .init { input, fromState in
-        for mapping in mappings {
-            if let tuple = mapping.run(input, fromState) {
-                return tuple
-            }
-        }
-        return nil
-    }
-}

--- a/Sources/Harvest/Mapping.swift
+++ b/Sources/Harvest/Mapping.swift
@@ -22,6 +22,21 @@ extension Harvester {
                 }
             }
         }
+
+        /// Folds multiple `Harvester.Mapping`s into one (preceding mapping has higher priority).
+        public static func reduce<Mappings: Sequence>(_ mappings: Mappings) -> Harvester<Input, State>.Mapping
+            where Mappings.Iterator.Element == Harvester<Input, State>.Mapping
+        {
+            return .init { input, fromState in
+                for mapping in mappings {
+                    if let toState = mapping.run(input, fromState) {
+                        return toState
+                    }
+                }
+                return nil
+            }
+        }
+
     }
 
     /// Transducer (input & output) mapping with
@@ -35,6 +50,22 @@ extension Harvester {
         public init(_ run: @escaping (Input, State) -> (State, Effect<Input, Queue, EffectID>)?)
         {
             self.run = run
+        }
+
+        /// Folds multiple `Harvester.EffectMapping`s into one (preceding mapping has higher priority).
+        public static func reduce<Mappings: Sequence, Queue, EffectID>(
+            _ mappings: Mappings
+        ) -> Harvester<Input, State>.EffectMapping<Queue, EffectID>
+            where Mappings.Iterator.Element == Harvester<Input, State>.EffectMapping<Queue, EffectID>
+        {
+            return .init { input, fromState in
+                for mapping in mappings {
+                    if let tuple = mapping.run(input, fromState) {
+                        return tuple
+                    }
+                }
+                return nil
+            }
         }
     }
 

--- a/Sources/Harvest/Mapping.swift
+++ b/Sources/Harvest/Mapping.swift
@@ -1,0 +1,41 @@
+extension Harvester {
+
+    /// Basic state-transition function type.
+    public struct Mapping
+    {
+        public let run: (Input, State) -> State?
+
+        public init(_ run: @escaping (Input, State) -> State?)
+        {
+            self.run = run
+        }
+
+        /// Converts `Mapping` to `EffectMapping`.
+        public func toEffectMapping<Queue, EffectID>() -> EffectMapping<Queue, EffectID>
+        {
+            .init { input, state in
+                if let toState = self.run(input, state) {
+                    return (toState, .none)
+                }
+                else {
+                    return nil
+                }
+            }
+        }
+    }
+
+    /// Transducer (input & output) mapping with
+    /// **cold publisher** (additional effect) as output,
+    /// which may emit next input values for continuous state-transitions.
+    public struct EffectMapping<Queue, EffectID>
+        where Queue: EffectQueueProtocol, EffectID: Equatable
+    {
+        public let run: (Input, State) -> (State, Effect<Input, Queue, EffectID>)?
+
+        public init(_ run: @escaping (Input, State) -> (State, Effect<Input, Queue, EffectID>)?)
+        {
+            self.run = run
+        }
+    }
+
+}

--- a/Sources/Harvest/Mapping.swift
+++ b/Sources/Harvest/Mapping.swift
@@ -1,5 +1,7 @@
-extension Harvester {
+// MARK: - Mapping
 
+extension Harvester
+{
     /// Basic state-transition function type.
     public struct Mapping
     {
@@ -36,9 +38,13 @@ extension Harvester {
                 return nil
             }
         }
-
     }
+}
 
+// MARK: - EffectMapping
+
+extension Harvester
+{
     /// Transducer (input & output) mapping with
     /// **cold publisher** (additional effect) as output,
     /// which may emit next input values for continuous state-transitions.
@@ -68,5 +74,4 @@ extension Harvester {
             }
         }
     }
-
 }

--- a/Tests/HarvestTests/AnyMappingSpec.swift
+++ b/Tests/HarvestTests/AnyMappingSpec.swift
@@ -29,7 +29,7 @@ class AnyMappingSpec: QuickSpec
                     any     | .state1 => .state2
                 ]
 
-                harvester = Harvester(state: .state0, inputs: inputs, mapping: reduce(mappings))
+                harvester = Harvester(state: .state0, inputs: inputs, mapping: .reduce(mappings))
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/EffectMappingLatestSpec.swift
+++ b/Tests/HarvestTests/EffectMappingLatestSpec.swift
@@ -47,7 +47,7 @@ class EffectMappingLatestSpec: QuickSpec
                     .logoutOK | .loggingOut => .loggedOut  | nil
                 ]
 
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: reduce(mappings))
+                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: .reduce(mappings))
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -48,7 +48,7 @@ class EffectMappingSpec: QuickSpec
                 ]
 
                 // strategy = `.merge`
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: reduce(mappings))
+                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: .reduce(mappings))
 
                 harvester.replies
                     .sink { reply in
@@ -200,7 +200,7 @@ class EffectMappingSpec: QuickSpec
                 ]
 
                 // strategy = `.merge`
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: reduce(mappings))
+                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: .reduce(mappings))
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -109,7 +109,7 @@ class EffectMappingSpec: QuickSpec
                         .delay(for: 1, scheduler: testScheduler)
                         .eraseToAnyPublisher()
 
-                let mapping: EffectMapping = { input, fromState in
+                let mapping: EffectMapping = .init { input, fromState in
                     switch (fromState, input) {
                         case (.loggedOut, .login):
                             return (.loggingIn, .init(loginOKPublisher))

--- a/Tests/HarvestTests/ExternalInputSpec.swift
+++ b/Tests/HarvestTests/ExternalInputSpec.swift
@@ -55,7 +55,7 @@ class ExternalInputSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: externalInputs.map(ExternalAuthInput.toInternal),
-                    mapping: reduce(mappings)
+                    mapping: .reduce(mappings)
                 )
 
                 harvester.replies

--- a/Tests/HarvestTests/FeedbackSpec.swift
+++ b/Tests/HarvestTests/FeedbackSpec.swift
@@ -50,7 +50,7 @@ class FeedbackSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: inputs,
-                    mapping: reduce(mappings),
+                    mapping: .reduce(mappings),
                     feedback: reduce([
                         Feedback(
                             filter: { $0.input == AuthInput.login },

--- a/Tests/HarvestTests/MappingCallCountSpec.swift
+++ b/Tests/HarvestTests/MappingCallCountSpec.swift
@@ -30,7 +30,7 @@ class MappingCallCountSpec: QuickSpec
             beforeEach {
                 mappingCallCount = 0
 
-                let mapping: Mapping = { input, state in
+                let mapping: Mapping = .init { input, state in
                     mappingCallCount += 1
 
                     switch input {

--- a/Tests/HarvestTests/MappingSpec.swift
+++ b/Tests/HarvestTests/MappingSpec.swift
@@ -128,7 +128,7 @@ class MappingSpec: QuickSpec
         describe("Func-based Mapping") {
 
             beforeEach {
-                let mapping: Mapping = { input, fromState in
+                let mapping: Mapping = .init { input, fromState in
                     switch (fromState, input) {
                         case (.loggedOut, .login):
                             return .loggingIn

--- a/Tests/HarvestTests/MappingSpec.swift
+++ b/Tests/HarvestTests/MappingSpec.swift
@@ -39,7 +39,7 @@ class MappingSpec: QuickSpec
                 ]
 
                 // NOTE: Use `concat` to combine all mappings.
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: reduce(mappings))
+                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: .reduce(mappings))
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/StateFuncMappingSpec.swift
+++ b/Tests/HarvestTests/StateFuncMappingSpec.swift
@@ -27,7 +27,7 @@ class StateFuncMappingSpec: QuickSpec
                 mappings += [ .decrement | { $0 - 1 } | .empty ]
 
                 // strategy = `.merge`
-                harvester = Harvester(state: 0, inputs: inputs, mapping: reduce(mappings))
+                harvester = Harvester(state: 0, inputs: inputs, mapping: .reduce(mappings))
             }
 
             it("`.increment` and `.decrement` succeed") {

--- a/Tests/HarvestTests/TerminatingSpec.swift
+++ b/Tests/HarvestTests/TerminatingSpec.swift
@@ -48,7 +48,7 @@ class TerminatingSpec: QuickSpec
                 ]
 
                 // strategy = `.merge`
-                harvester = Harvester(state: .state0, inputs: inputs, mapping: reduce(mappings))
+                harvester = Harvester(state: .state0, inputs: inputs, mapping: .reduce(mappings))
 
                 harvester.replies
                     .sink(

--- a/Tests/HarvestTests/TimerSubscriptionSpec.swift
+++ b/Tests/HarvestTests/TimerSubscriptionSpec.swift
@@ -38,7 +38,7 @@ class TimerSubscriptionSpec: QuickSpec
                     .map(TimerInput.tick)
                     .eraseToAnyPublisher()
 
-                let mapping: EffectMapping = { input, state in
+                let mapping: EffectMapping = .init { input, state in
                     switch input {
                     case .start:
                         return (state, Effect(timerPublisher, id: "timer"))


### PR DESCRIPTION
This PR changes `Mapping` & `EffectMapping` function types to struct.
One benefit is that we can add methods on top of these new types e.g. `toEffectMapping()` .