### PR TITLE
Add `Effect.mapQueue` and `.invmapID`

### DIFF
--- a/Sources/Harvest/Mapping.swift
+++ b/Sources/Harvest/Mapping.swift
@@ -58,6 +58,28 @@ extension Harvester
             self.run = run
         }
 
+        public func mapQueue<Queue2>(_ f: @escaping (Queue) -> Queue2)
+            -> Harvester<Input, State>.EffectMapping<Queue2, EffectID>
+        {
+            return .init { input, state in
+                guard let (newState, effect) = self.run(input, state) else { return nil }
+                let effect2 = effect.mapQueue(f)
+                return (newState, effect2)
+            }
+        }
+
+        public func invmapID<EffectID2>(
+            _ forward: @escaping (EffectID) -> EffectID2,
+            _ backward: @escaping (EffectID2) -> EffectID
+        ) -> Harvester<Input, State>.EffectMapping<Queue, EffectID2>
+        {
+            return .init { input, state in
+                guard let (newState, effect) = self.run(input, state) else { return nil }
+                let effect2 = effect.invmapID(forward, backward)
+                return (newState, effect2)
+            }
+        }
+
         /// Folds multiple `Harvester.EffectMapping`s into one (preceding mapping has higher priority).
         public static func reduce<Mappings: Sequence, Queue, EffectID>(
             _ mappings: Mappings
@@ -73,5 +95,6 @@ extension Harvester
                 return nil
             }
         }
+
     }
 }


### PR DESCRIPTION
This PR provides a way of transforming `Effect<Input, Queue, ID>` into `Effect<Input, Queue2, ID2>` by adding `func mapQueue` and `func invmapID` .

Alongside `Effect.mapInput`, these functions are useful for `EffectMapping` composition.