### PR TITLE
Add `scheduler` as `Harvester.init` parameter

### DIFF
--- a/Sources/Harvest/Harvester+Feedback.swift
+++ b/Sources/Harvest/Harvester+Feedback.swift
@@ -9,12 +9,16 @@ extension Harvester
     ///   - input: External "hot" input stream that `Harvester` receives.
     ///   - mapping: Simple `Mapping` that designates next state only (no additional effect).
     ///   - feedback: `Publisher` transformer that performs side-effect and emits next input.
-    public convenience init<Inputs: Publisher>(
+    ///   - scheduler: Scheduler for next inputs from `Feedback`.
+    ///   - options: `scheduler` options.
+    public convenience init<Inputs: Publisher, S: Scheduler>(
         state initialState: State,
         inputs inputSignal: Inputs,
         mapping: Mapping,
-        feedback: Feedback<Reply<Input, State>.Success, Input>
-        )
+        feedback: Feedback<Reply<Input, State>.Success, Input>,
+        scheduler: S,
+        options: S.SchedulerOptions? = nil
+    )
         where Inputs.Output == Input, Inputs.Failure == Never
     {
         self.init(
@@ -41,7 +45,8 @@ extension Harvester
                 let effects = feedback.transform(replies.compactMap { $0.success }.eraseToAnyPublisher())
 
                 return (replies, effects)
-            }
+            },
+            scheduler: scheduler
         )
     }
 }

--- a/Tests/HarvestTests/AnyMappingSpec.swift
+++ b/Tests/HarvestTests/AnyMappingSpec.swift
@@ -29,7 +29,12 @@ class AnyMappingSpec: QuickSpec
                     any     | .state1 => .state2
                 ]
 
-                harvester = Harvester(state: .state0, inputs: inputs, mapping: .reduce(mappings))
+                harvester = Harvester(
+                    state: .state0,
+                    inputs: inputs,
+                    mapping: .reduce(mappings),
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/EffectMappingLatestSpec.swift
+++ b/Tests/HarvestTests/EffectMappingLatestSpec.swift
@@ -47,7 +47,12 @@ class EffectMappingLatestSpec: QuickSpec
                     .logoutOK | .loggingOut => .loggedOut  | nil
                 ]
 
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: .reduce(mappings))
+                harvester = Harvester(
+                    state: .loggedOut,
+                    inputs: inputs,
+                    mapping: .reduce(mappings),
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -37,7 +37,7 @@ class EffectMappingSpec: QuickSpec
                 /// Sends `.logoutOK` after delay, simulating async work during `.loggingOut`.
                 let logoutOKPublisher =
                     Just(AuthInput.logoutOK)
-                        .delay(for: 1, scheduler: testScheduler!)
+                        .delay(for: 1, scheduler: testScheduler)
                         .eraseToAnyPublisher()
 
                 let mappings: [EffectMapping] = [
@@ -48,7 +48,12 @@ class EffectMappingSpec: QuickSpec
                 ]
 
                 // strategy = `.merge`
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: .reduce(mappings))
+                harvester = Harvester(
+                    state: .loggedOut,
+                    inputs: inputs,
+                    mapping: .reduce(mappings),
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink { reply in
@@ -125,7 +130,12 @@ class EffectMappingSpec: QuickSpec
                 }
 
                 // strategy = `.merge`
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: mapping)
+                harvester = Harvester(
+                    state: .loggedOut,
+                    inputs: inputs,
+                    mapping: mapping,
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink { reply in
@@ -200,7 +210,12 @@ class EffectMappingSpec: QuickSpec
                 ]
 
                 // strategy = `.merge`
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: .reduce(mappings))
+                harvester = Harvester(
+                    state: .loggedOut,
+                    inputs: inputs,
+                    mapping: .reduce(mappings),
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/ExternalInputSpec.swift
+++ b/Tests/HarvestTests/ExternalInputSpec.swift
@@ -37,7 +37,7 @@ class ExternalInputSpec: QuickSpec
                 /// Sends `.logoutOK` after delay, simulating async work during `.loggingOut`.
                 let logoutOKPublisher =
                     Just(AuthInput.logoutOK)
-                        .delay(for: 1, scheduler: testScheduler!)
+                        .delay(for: 1, scheduler: testScheduler)
                         .eraseToAnyPublisher()
 
                 // NOTE: predicate style i.e. `T -> Bool` is also available.
@@ -55,7 +55,8 @@ class ExternalInputSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: externalInputs.map(ExternalAuthInput.toInternal),
-                    mapping: .reduce(mappings)
+                    mapping: .reduce(mappings),
+                    scheduler: ImmediateScheduler.shared
                 )
 
                 harvester.replies

--- a/Tests/HarvestTests/FeedbackSpec.swift
+++ b/Tests/HarvestTests/FeedbackSpec.swift
@@ -60,7 +60,8 @@ class FeedbackSpec: QuickSpec
                             filter: { $0.input == AuthInput.logout },
                             produce: { _ in logoutOKProducer }
                         )
-                    ])
+                    ]),
+                    scheduler: ImmediateScheduler.shared
                 )
 
                 harvester.replies

--- a/Tests/HarvestTests/MappingCallCountSpec.swift
+++ b/Tests/HarvestTests/MappingCallCountSpec.swift
@@ -39,7 +39,12 @@ class MappingCallCountSpec: QuickSpec
                     }
                 }
 
-                harvester = Harvester(state: 0, inputs: inputs, mapping: mapping)
+                harvester = Harvester(
+                    state: 0,
+                    inputs: inputs,
+                    mapping: mapping,
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/MappingSpec.swift
+++ b/Tests/HarvestTests/MappingSpec.swift
@@ -39,7 +39,12 @@ class MappingSpec: QuickSpec
                 ]
 
                 // NOTE: Use `concat` to combine all mappings.
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: .reduce(mappings))
+                harvester = Harvester(
+                    state: .loggedOut,
+                    inputs: inputs,
+                    mapping: .reduce(mappings),
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink { reply in
@@ -148,7 +153,12 @@ class MappingSpec: QuickSpec
                     }
                 }
 
-                harvester = Harvester(state: .loggedOut, inputs: inputs, mapping: mapping)
+                harvester = Harvester(
+                    state: .loggedOut,
+                    inputs: inputs,
+                    mapping: mapping,
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink { reply in

--- a/Tests/HarvestTests/StateFuncMappingSpec.swift
+++ b/Tests/HarvestTests/StateFuncMappingSpec.swift
@@ -27,7 +27,12 @@ class StateFuncMappingSpec: QuickSpec
                 mappings += [ .decrement | { $0 - 1 } | .empty ]
 
                 // strategy = `.merge`
-                harvester = Harvester(state: 0, inputs: inputs, mapping: .reduce(mappings))
+                harvester = Harvester(
+                    state: 0,
+                    inputs: inputs,
+                    mapping: .reduce(mappings),
+                    scheduler: ImmediateScheduler.shared
+                )
             }
 
             it("`.increment` and `.decrement` succeed") {

--- a/Tests/HarvestTests/TerminatingSpec.swift
+++ b/Tests/HarvestTests/TerminatingSpec.swift
@@ -48,7 +48,12 @@ class TerminatingSpec: QuickSpec
                 ]
 
                 // strategy = `.merge`
-                harvester = Harvester(state: .state0, inputs: inputs, mapping: .reduce(mappings))
+                harvester = Harvester(
+                    state: .state0,
+                    inputs: inputs,
+                    mapping: .reduce(mappings),
+                    scheduler: ImmediateScheduler.shared
+                )
 
                 harvester.replies
                     .sink(

--- a/Tests/HarvestTests/TimerSubscriptionSpec.swift
+++ b/Tests/HarvestTests/TimerSubscriptionSpec.swift
@@ -54,7 +54,8 @@ class TimerSubscriptionSpec: QuickSpec
                 harvester = Harvester(
                     state: 0,
                     inputs: inputs,
-                    mapping: mapping
+                    mapping: mapping,
+                    scheduler: ImmediateScheduler.shared
                 )
 
                 harvester.replies


### PR DESCRIPTION
This PR adds `scheduler` as `Harvester.init` parameter since "synchronous `Input` feedback loop" (reentrancy) will cause crash in Combine.framework.

Previously, it was user's responsibility to add `receive(on:)` whenever needed for synchronous side-effects and next inputs, but I decided to implement this logic inside `Harvester` to mitigate the verbose user-side implementation.