### PR TITLE
Add `EffectMapping.makeInout` & rename `Effect.none` to `.empty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ let mappings: [EffectMapping] = [
   /*  Input   |   fromState => toState     |      Effect       */
   /* ----------------------------------------------------------*/
     .login    | .loggedOut  => .loggingIn  | Effect(loginOKPublisher, queue: .request),
-    .loginOK  | .loggingIn  => .loggedIn   | nil,
+    .loginOK  | .loggingIn  => .loggedIn   | .empty,
     .logout   | .loggedIn   => .loggingOut | Effect(logoutOKPublisher, queue: .request),
-    .logoutOK | .loggingOut => .loggedOut  | nil,
+    .logoutOK | .loggingOut => .loggedOut  | .empty,
 
     .forceLogout | canForceLogout => .loggingOut | Effect(forceLogoutOKPublisher, queue: .request)
 ]

--- a/Sources/Harvest/Effect.swift
+++ b/Sources/Harvest/Effect.swift
@@ -55,7 +55,7 @@ public struct Effect<Input, Queue, ID>
     }
 
     /// Empty side-effect.
-    public static var none: Effect<Input, Queue, ID>
+    public static var empty: Effect<Input, Queue, ID>
     {
         return Effect(.empty)
     }
@@ -105,14 +105,6 @@ public struct Effect<Input, Queue, ID>
         case let .cancel(predicate):
             return .cancel { predicate(backword($0)) }
         }
-    }
-}
-
-extension Effect: ExpressibleByNilLiteral
-{
-    public init(nilLiteral: ())
-    {
-        self = .none
     }
 }
 

--- a/Sources/Harvest/Harvester.swift
+++ b/Sources/Harvest/Harvester.swift
@@ -31,7 +31,7 @@ public final class Harvester<Input, State>
         self.init(
             state: initialState,
             inputs: inputSignal,
-            mapping: .init { mapping.run($0, $1).map { ($0, Effect<Input, BasicEffectQueue, Never>.none) } },
+            mapping: .init { mapping.run($0, $1).map { ($0, Effect<Input, BasicEffectQueue, Never>.empty) } },
             scheduler: scheduler,
             options: options
         )
@@ -48,7 +48,7 @@ public final class Harvester<Input, State>
     ///   - options: `scheduler` options.
     public convenience init<Inputs: Publisher, Queue: EffectQueueProtocol, EffectID, S: Scheduler>(
         state initialState: State,
-        effect initialEffect: Effect<Input, Queue, EffectID> = .none,
+        effect initialEffect: Effect<Input, Queue, EffectID> = .empty,
         inputs inputSignal: Inputs,
         mapping: EffectMapping<Queue, EffectID>,
         scheduler: S,
@@ -79,7 +79,7 @@ public final class Harvester<Input, State>
 
                 let effects = mapped
                     .compactMap { _, _, mapped -> Effect<Input, Queue, EffectID> in
-                        guard case let .some(_, effect) = mapped else { return .none }
+                        guard case let .some(_, effect) = mapped else { return .empty }
                         return effect
                     }
                     .prepend(initialEffect)

--- a/Sources/HarvestStore/Store.swift
+++ b/Sources/HarvestStore/Store.swift
@@ -17,7 +17,7 @@ public final class Store<Input, State>: ObservableObject
 
     public init<Queue: EffectQueueProtocol, EffectID, S: Scheduler>(
         state initialState: State,
-        effect initialEffect: Effect<Input, Queue, EffectID> = .none,
+        effect initialEffect: Effect<Input, Queue, EffectID> = .empty,
         mapping: Harvester<Input, State>.EffectMapping<Queue, EffectID>,
         scheduler: S,
         options: S.SchedulerOptions? = nil
@@ -115,7 +115,7 @@ private func lift<Input, State, Queue: EffectQueueProtocol, EffectID>(
             return (newState, effect.mapInput(Store<Input, State>.BindableInput.input))
 
         case let .state(state):
-            return (state, nil)
+            return (state, .empty)
         }
     }
 }

--- a/Tests/HarvestTests/EffectMappingLatestSpec.swift
+++ b/Tests/HarvestTests/EffectMappingLatestSpec.swift
@@ -42,9 +42,9 @@ class EffectMappingLatestSpec: QuickSpec
 
                 let mappings: [EffectMapping] = [
                     .login    | .loggedOut  => .loggingIn  | Effect(loginOKProducer, queue: .request),
-                    .loginOK  | .loggingIn  => .loggedIn   | nil,
+                    .loginOK  | .loggingIn  => .loggedIn   | .empty,
                     .logout   | .loggedIn   => .loggingOut | Effect(logoutOKProducer, queue: .request),
-                    .logoutOK | .loggingOut => .loggedOut  | nil
+                    .logoutOK | .loggingOut => .loggedOut  | .empty
                 ]
 
                 harvester = Harvester(

--- a/Tests/HarvestTests/TimerSubscriptionSpec.swift
+++ b/Tests/HarvestTests/TimerSubscriptionSpec.swift
@@ -44,7 +44,7 @@ class TimerSubscriptionSpec: QuickSpec
                         return (state, Effect(timerPublisher, id: "timer"))
 
                     case let .tick(newState):
-                        return (newState, .none)
+                        return (newState, .empty)
 
                     case .stop:
                         return (state, Effect.cancel("timer"))


### PR DESCRIPTION
This PR adds `EffectMapping.makeInout` as `inout`-based initializer for easier mapping implementation.

But to achieve this, `EffectMapping.makeInout` argument's return type will have `Optional<Effect>` where current implementation has `Effect.none` with `ExpressibleByNilLiteral` which becomes ambiguous to `Optional`, so I renamed `Effect.none` to `.empty`, and removed `ExpressibleByNilLiteral`. 