### PR TITLE
Revert #13 where `scheduler` is applied to `inputs` that cause delayed UI rendering

### DIFF
--- a/Sources/Harvest/Harvester+Feedback.swift
+++ b/Sources/Harvest/Harvester+Feedback.swift
@@ -9,7 +9,7 @@ extension Harvester
     ///   - inputs: External "hot" input stream that `Harvester` receives.
     ///   - mapping: Simple `Mapping` that designates next state only (no additional effect).
     ///   - feedback: `Publisher` transformer that performs side-effect and emits next input.
-    ///   - scheduler: Scheduler for `inputs` and next inputs from `Feedback`.
+    ///   - scheduler: Scheduler for next inputs from `Feedback`. (NOTE: This should be on the same thread as `inputs`)
     ///   - options: `scheduler` options.
     public convenience init<Inputs: Publisher, S: Scheduler>(
         state initialState: State,

--- a/Sources/HarvestStore/Store.swift
+++ b/Sources/HarvestStore/Store.swift
@@ -33,7 +33,6 @@ public final class Store<Input, State>: ObservableObject
         )
 
         self.objectWillChange = self.harvester.$state
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
 
         // Comment-out:


### PR DESCRIPTION
Related: #12 #13 

This PR reverts #13 where `scheduler` is also applied to external `inputs`.
Unfortunately, this caused **delayed UI rendering** that becomes annoying especially in SwiftUI which uses synchronous UI binding update.

Since `inputs.receive(on: scheduler)` is not a requirement for avoiding synchronous feedback crash (though it improves thread safety), this PR will apply `scheduler` only for `effectInputs`.

Downside of this change is that user needs to be aware of thread-safety issue as commented in documentation:

```
NOTE: This (`scheduler`) should be on the same thread as `inputs`
```

But still, having `scheduler` parameter is (probably) better than going back before #12 .