### PR TITLE
Make `Effect` & `EffectMapping` a monoid structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ var cancellables: [AnyCancellable] = []
 let harvester = Harvester(
     state: .loggedOut,
     input: inputs,
-    mapping: .reduce(mappings),  // combine mappings using `reduce` helper
+    mapping: .reduce(.first, mappings),  // combine mappings using `reduce` helper
     scheduler: DispatchQueue.main
 )
 

--- a/Sources/Harvest/Harvester.swift
+++ b/Sources/Harvest/Harvester.swift
@@ -85,8 +85,11 @@ public final class Harvester<Input, State>
                     .prepend(initialEffect)
                     .share()
 
-                let tasks = effects.compactMap { $0.task }
-                let cancels = effects.compactMap { $0.cancel }
+                let tasks = effects.map { $0.tasks }
+                    .flatMap { Publishers.Sequence(sequence: $0) }
+
+                let cancels = effects.map { $0.cancels }
+                    .flatMap { Publishers.Sequence(sequence: $0) }
 
                 let effectInputs = Publishers.MergeMany(
                     Queue.allCases.map { queue in

--- a/Sources/Harvest/Harvester.swift
+++ b/Sources/Harvest/Harvester.swift
@@ -86,10 +86,10 @@ public final class Harvester<Input, State>
                     .share()
 
                 let tasks = effects.map { $0.tasks }
-                    .flatMap { Publishers.Sequence(sequence: $0) }
+                    .flatMap(Publishers.Sequence.init(sequence:))
 
                 let cancels = effects.map { $0.cancels }
-                    .flatMap { Publishers.Sequence(sequence: $0) }
+                    .flatMap(Publishers.Sequence.init(sequence:))
 
                 let effectInputs = Publishers.MergeMany(
                     Queue.allCases.map { queue in

--- a/Sources/Harvest/Mapping.swift
+++ b/Sources/Harvest/Mapping.swift
@@ -36,6 +36,8 @@ extension Harvester
             }
         }
 
+        // MARK: - Conversion
+
         /// Converts `Mapping` to `EffectMapping`.
         public func toEffectMapping<Queue, EffectID>() -> EffectMapping<Queue, EffectID>
         {
@@ -49,17 +51,96 @@ extension Harvester
             }
         }
 
-        /// Folds multiple `Harvester.Mapping`s into one (preceding mapping has higher priority).
-        public static func reduce<Mappings: Sequence>(_ mappings: Mappings) -> Harvester<Input, State>.Mapping
-            where Mappings.Iterator.Element == Harvester<Input, State>.Mapping
+        // MARK: - Monoid
+
+        public static var zero: Mapping
         {
-            return .init { input, fromState in
-                for mapping in mappings {
-                    if let toState = mapping.run(input, fromState) {
-                        return toState
+            .init { input, state in nil }
+        }
+
+        public static var one: Mapping
+        {
+            .init { input, state in state }
+        }
+
+        public static func + (l: Mapping, r: Mapping) -> Mapping
+        {
+            .init { input, state in
+                l.run(input, state) ?? r.run(input, state)
+            }
+        }
+
+        public static func * (l: Mapping, r: Mapping) -> Mapping
+        {
+            .init { input, state in
+                l.run(input, state).flatMap { r.run(input, $0) }
+            }
+        }
+
+        // MARK: - Foldable
+
+        /// Folds multiple `Harvester.Mapping`s into one.
+        public static func reduce<Mappings: Sequence>(
+            _ strategy: ReduceStrategy,
+            _ mappings: Mappings
+        ) -> Mapping
+            where Mappings.Iterator.Element == Mapping
+        {
+            strategy.reduce(AnySequence(mappings))
+        }
+
+        /// Strategy for various ways of reducing mappings into a single value.
+        public struct ReduceStrategy
+        {
+            fileprivate let reduce: (AnySequence<Mapping>) -> Mapping
+
+            private init(
+                reduce: @escaping (AnySequence<Mapping>) -> Mapping
+            )
+            {
+                self.reduce = reduce
+            }
+
+            /// Chooses a first non-`nil`-returning mapping from given mappings.
+            public static var first: ReduceStrategy
+            {
+                .init { mappings in
+                    mappings.reduce(into: .zero, { $0 = $0 + $1 })
+                }
+            }
+
+            /// Tries applying all mappings sequentially,
+            /// and succeeds only if all mappings don't have `nil`-return.
+            public static var tryAll: ReduceStrategy
+            {
+                .init { mappings in
+                    mappings.reduce(into: .one, { $0 = $0 * $1 })
+                }
+            }
+
+            /// Applies all mappings sequentially, skipping `nil`-return mapping.
+            /// If all mappings's transitions failed, then returned mapping
+            /// will also be marked as transition failure.
+            public static var all: ReduceStrategy
+            {
+                .init { mappings in
+                    // Comment-Out: Need to track all transition failures.
+                    //mappings.reduce(into: .one, { $0 = $0 * ($1 + .one) })
+
+                    Mapping { input, state in
+                        var state = state
+                        var isTransitionSucceeded = false
+
+                        for mapping in mappings {
+                            if let newState = mapping.run(input, state) {
+                                state = newState
+                                isTransitionSucceeded = true
+                            }
+                        }
+
+                        return isTransitionSucceeded ? state : nil
                     }
                 }
-                return nil
             }
         }
     }
@@ -98,8 +179,40 @@ extension Harvester
             }
         }
 
+        // MARK: - Monoid
+
+        public static var zero: EffectMapping
+        {
+            .init { input, state in nil }
+        }
+
+        public static var one: EffectMapping
+        {
+            .init { input, state in (state, .empty) }
+        }
+
+        public static func + (l: EffectMapping, r: EffectMapping) -> EffectMapping
+        {
+            .init { input, state in
+                l.run(input, state) ?? r.run(input, state)
+            }
+        }
+
+        public static func * (l: EffectMapping, r: EffectMapping) -> EffectMapping
+        {
+            .init { input, state in
+                l.run(input, state).flatMap { state2, effect in
+                    r.run(input, state2).map { state3, effect2 in
+                        (state3, effect + effect2)
+                    }
+                }
+            }
+        }
+
+        // MARK: - Functor
+
         public func mapQueue<Queue2>(_ f: @escaping (Queue) -> Queue2)
-            -> Harvester<Input, State>.EffectMapping<Queue2, EffectID>
+            -> EffectMapping<Queue2, EffectID>
         {
             return .init { input, state in
                 guard let (newState, effect) = self.run(input, state) else { return nil }
@@ -108,19 +221,72 @@ extension Harvester
             }
         }
 
-        /// Folds multiple `Harvester.EffectMapping`s into one (preceding mapping has higher priority).
-        public static func reduce<Mappings: Sequence, Queue, EffectID>(
+        // MARK: - Foldable
+
+        /// Folds multiple `Harvester.EffectMapping`s into one.
+        public static func reduce<Mappings: Sequence>(
+            _ strategy: ReduceStrategy,
             _ mappings: Mappings
-        ) -> Harvester<Input, State>.EffectMapping<Queue, EffectID>
-            where Mappings.Iterator.Element == Harvester<Input, State>.EffectMapping<Queue, EffectID>
+        ) -> EffectMapping
+            where Mappings.Iterator.Element == EffectMapping
         {
-            return .init { input, fromState in
-                for mapping in mappings {
-                    if let tuple = mapping.run(input, fromState) {
-                        return tuple
+            strategy.reduce(AnySequence(mappings))
+        }
+
+        /// Strategy for various ways of reducing mappings into a single value.
+        public struct ReduceStrategy
+        {
+            fileprivate let reduce: (AnySequence<EffectMapping>) -> EffectMapping
+
+            private init(
+                reduce: @escaping (AnySequence<EffectMapping>) -> EffectMapping
+            )
+            {
+                self.reduce = reduce
+            }
+
+            /// Chooses a first non-`nil`-returning mapping from given mappings.
+            public static var first: ReduceStrategy
+            {
+                .init { mappings in
+                    mappings.reduce(into: .zero, { $0 = $0 + $1 })
+                }
+            }
+
+            /// Tries applying all mappings sequentially,
+            /// and succeeds only if all mappings don't have `nil`-return.
+            public static var tryAll: ReduceStrategy
+            {
+                .init { mappings in
+                    mappings.reduce(into: .one, { $0 = $0 * $1 })
+                }
+            }
+
+            /// Applies all mappings sequentially, skipping `nil`-return mapping.
+            /// If all mappings's transitions failed, then returned mapping
+            /// will also be marked as transition failure.
+            public static var all: ReduceStrategy
+            {
+                .init { mappings in
+                    // Comment-Out: Need to track all transition failures.
+                    //mappings.reduce(into: .one, { $0 = $0 * ($1 + .one) })
+
+                    EffectMapping { input, state in
+                        var state = state
+                        var effect = Effect<Input, Queue, EffectID>.empty
+                        var isTransitionSucceeded = false
+
+                        for mapping in mappings {
+                            if let (newState, newEffect) = mapping.run(input, state) {
+                                state = newState
+                                effect = effect + newEffect
+                                isTransitionSucceeded = true
+                            }
+                        }
+
+                        return isTransitionSucceeded ? (state, effect) : nil
                     }
                 }
-                return nil
             }
         }
 

--- a/Sources/HarvestOptics/Effect+Optics.swift
+++ b/Sources/HarvestOptics/Effect+Optics.swift
@@ -8,17 +8,19 @@ extension Harvest.Effect
         id prism: Prism<WholeID, ID>
     ) -> Effect<Input, Queue, WholeID>
     {
-        switch self.kind {
-        case let .task(task):
-            return .init(kind: .task(Effect<Input, Queue, WholeID>.Task(
-                publisher: task.publisher,
-                queue: task.queue,
-                id: task.id.map(prism.inject)
-            )))
-        case let .cancel(predicate):
-            return .cancel {
-                prism.tryGet($0).map(predicate) ?? false
+        .init(kinds: self.kinds.map { kind in
+            switch kind {
+            case let .task(task):
+                return .task(.init(
+                    publisher: task.publisher,
+                    queue: task.queue,
+                    id: task.id.map(prism.inject)
+                ))
+            case let .cancel(predicate):
+                return .cancel {
+                    prism.tryGet($0).map(predicate) ?? false
+                }
             }
-        }
+        })
     }
 }

--- a/Tests/HarvestTests/AnyMappingSpec.swift
+++ b/Tests/HarvestTests/AnyMappingSpec.swift
@@ -32,7 +32,7 @@ class AnyMappingSpec: QuickSpec
                 harvester = Harvester(
                     state: .state0,
                     inputs: inputs,
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     scheduler: ImmediateScheduler.shared
                 )
 

--- a/Tests/HarvestTests/EffectMappingLatestSpec.swift
+++ b/Tests/HarvestTests/EffectMappingLatestSpec.swift
@@ -48,7 +48,7 @@ class EffectMappingLatestSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: inputs,
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     scheduler: ImmediateScheduler.shared
                 )
 

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -51,7 +51,7 @@ class EffectMappingSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: inputs,
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     scheduler: ImmediateScheduler.shared
                 )
 
@@ -299,7 +299,7 @@ class EffectMappingSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: inputs,
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     scheduler: ImmediateScheduler.shared
                 )
 

--- a/Tests/HarvestTests/ExternalInputSpec.swift
+++ b/Tests/HarvestTests/ExternalInputSpec.swift
@@ -53,7 +53,7 @@ class ExternalInputSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: externalInputs.map(ExternalAuthInput.toInternal),
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     scheduler: ImmediateScheduler.shared
                 )
 

--- a/Tests/HarvestTests/FeedbackSpec.swift
+++ b/Tests/HarvestTests/FeedbackSpec.swift
@@ -50,7 +50,7 @@ class FeedbackSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: inputs,
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     feedback: reduce([
                         Feedback(
                             filter: { $0.input == AuthInput.login },

--- a/Tests/HarvestTests/MappingSpec.swift
+++ b/Tests/HarvestTests/MappingSpec.swift
@@ -42,7 +42,7 @@ class MappingSpec: QuickSpec
                 harvester = Harvester(
                     state: .loggedOut,
                     inputs: inputs,
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     scheduler: ImmediateScheduler.shared
                 )
 

--- a/Tests/HarvestTests/StateFuncMappingSpec.swift
+++ b/Tests/HarvestTests/StateFuncMappingSpec.swift
@@ -30,7 +30,7 @@ class StateFuncMappingSpec: QuickSpec
                 harvester = Harvester(
                     state: 0,
                     inputs: inputs,
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     scheduler: ImmediateScheduler.shared
                 )
             }

--- a/Tests/HarvestTests/TerminatingSpec.swift
+++ b/Tests/HarvestTests/TerminatingSpec.swift
@@ -51,7 +51,7 @@ class TerminatingSpec: QuickSpec
                 harvester = Harvester(
                     state: .state0,
                     inputs: inputs,
-                    mapping: .reduce(mappings),
+                    mapping: .reduce(.first, mappings),
                     scheduler: ImmediateScheduler.shared
                 )
 


### PR DESCRIPTION
This PR adds `Effect`, `Mapping`, and `EffectMapping` conforming to **Monoid structure** (2 instances are combine-able with associativity and has identity) for better composition.

Please note that `EffectMapping` will now have **multiple ways of conforming to Monoid** since its internal structure is `Input -> State -> (State, Effect)?` returning `Optional` as the architectural choice.

Because of this, `static func reduce` will now introduce **`enum ReduceStrategy { case first, all, tryAll }`** for various reducing strategies.

(Previously, this reducing strategy was assumed to have `.first` only (picking one of the mapping from array), but this prevents from sibling mappings composition, so having `.all` is essentially needed to behave just as same behavior as `Input -> State -> (State, Effect)` which returns `Identity(Monad)` .