### PR TITLE
Control the World

### DIFF
--- a/Sources/Harvest/Mapping+Helper.swift
+++ b/Sources/Harvest/Mapping+Helper.swift
@@ -79,19 +79,19 @@ public func | <Input: Equatable, State>(
 
 // MARK: `|` (Harvester.EffectMapping constructor)
 
-public func | <P: Publisher, Input, State, Queue, EffectID>(
+public func | <World, P: Publisher, Input, State, Queue, EffectID>(
     mapping: Harvester<Input, State>.Mapping,
     publisher: P
-) -> Harvester<Input, State>.EffectMapping<Queue, EffectID>
+) -> Harvester<Input, State>.EffectMapping<World, Queue, EffectID>
     where P.Output == Input, P.Failure == Never
 {
     return mapping | Effect(publisher)
 }
 
-public func | <Input, State, Queue, EffectID>(
+public func | <World, Input, State, Queue, EffectID>(
     mapping: Harvester<Input, State>.Mapping,
-    effect: Effect<Input, Queue, EffectID>
-    ) -> Harvester<Input, State>.EffectMapping<Queue, EffectID>
+    effect: Effect<World, Input, Queue, EffectID>
+    ) -> Harvester<Input, State>.EffectMapping<World, Queue, EffectID>
 {
     return .init { input, fromState in
         if let toState = mapping.run(input, fromState) {

--- a/Sources/HarvestOptics/Effect+Optics.swift
+++ b/Sources/HarvestOptics/Effect+Optics.swift
@@ -6,7 +6,7 @@ extension Harvest.Effect
     /// Transforms `Effect` from `ID` to `WholeID`.
     public func transform<WholeID>(
         id prism: Prism<WholeID, ID>
-    ) -> Effect<Input, Queue, WholeID>
+    ) -> Effect<World, Input, Queue, WholeID>
     {
         .init(kinds: self.kinds.map { kind in
             switch kind {

--- a/Sources/HarvestOptics/EffectMapping+Optics.swift
+++ b/Sources/HarvestOptics/EffectMapping+Optics.swift
@@ -6,7 +6,7 @@ extension Harvester.EffectMapping
     /// Transforms `EffectMapping` from `Input` to `WholeInput`.
     public func transform<WholeInput>(
         input inputTraversal: AffineTraversal<WholeInput, Input>
-    ) -> Harvester<WholeInput, State>.EffectMapping<Queue, EffectID>
+    ) -> Harvester<WholeInput, State>.EffectMapping<World, Queue, EffectID>
     {
         return .init { wholeInput, state in
             guard let partInput = inputTraversal.tryGet(wholeInput),
@@ -21,7 +21,7 @@ extension Harvester.EffectMapping
     /// Transforms `EffectMapping` from `State` to `WholeState`.
     public func transform<WholeState>(
         state stateTraversal: AffineTraversal<WholeState, State>
-    ) -> Harvester<Input, WholeState>.EffectMapping<Queue, EffectID>
+    ) -> Harvester<Input, WholeState>.EffectMapping<World, Queue, EffectID>
     {
         return .init { input, wholeState in
             guard let partState = stateTraversal.tryGet(wholeState),
@@ -39,7 +39,7 @@ extension Harvester.EffectMapping
     /// Transforms `EffectMapping` from `ID` to `WholeID`.
     public func transform<WholeEffectID>(
         id prism: Prism<WholeEffectID, EffectID>
-    ) -> Harvester<Input, State>.EffectMapping<Queue, WholeEffectID>
+    ) -> Harvester<Input, State>.EffectMapping<World, Queue, WholeEffectID>
     {
         return .init { input, state in
             guard let (newState, effect) = self.run(input, state) else { return nil }

--- a/Sources/HarvestStore/Store.swift
+++ b/Sources/HarvestStore/Store.swift
@@ -15,10 +15,11 @@ public final class Store<Input, State>: ObservableObject
 
     public let objectWillChange: AnyPublisher<State, Never>
 
-    public init<Queue: EffectQueueProtocol, EffectID>(
+    public init<World, Queue: EffectQueueProtocol, EffectID>(
         state initialState: State,
-        effect initialEffect: Effect<Input, Queue, EffectID> = .empty,
-        mapping: Harvester<Input, State>.EffectMapping<Queue, EffectID>
+        effect initialEffect: Effect<World, Input, Queue, EffectID> = .empty,
+        mapping: Harvester<Input, State>.EffectMapping<World, Queue, EffectID>,
+        world: World
     )
     {
         self.harvester = Harvester(
@@ -26,6 +27,7 @@ public final class Store<Input, State>: ObservableObject
             effect: initialEffect.mapInput(Store<Input, State>.BindableInput.input),
             inputs: self.inputs,
             mapping: lift(effectMapping: mapping),
+            world: world,
             scheduler: DispatchQueue.main
         )
 
@@ -92,15 +94,15 @@ extension Store
 
 extension Store
 {
-    fileprivate typealias EffectMapping<Queue, EffectID> =
-        Harvester<BindableInput, State>.EffectMapping<Queue, EffectID>
+    fileprivate typealias EffectMapping<World, Queue, EffectID> =
+        Harvester<BindableInput, State>.EffectMapping<World, Queue, EffectID>
         where Queue: EffectQueueProtocol, EffectID: Equatable
 }
 
 /// Lifts from `Harvester.EffectMapping` to `Store.EffectMapping`, converting from `Input` to `Store.BindableInput`.
-private func lift<Input, State, Queue: EffectQueueProtocol, EffectID>(
-    effectMapping: Harvester<Input, State>.EffectMapping<Queue, EffectID>
-) -> Store<Input, State>.EffectMapping<Queue, EffectID>
+private func lift<World, Input, State, Queue: EffectQueueProtocol, EffectID>(
+    effectMapping: Harvester<Input, State>.EffectMapping<World, Queue, EffectID>
+) -> Store<Input, State>.EffectMapping<World, Queue, EffectID>
 {
     .init { input, state in
         switch input {

--- a/Tests/HarvestTests/EffectMappingLatestSpec.swift
+++ b/Tests/HarvestTests/EffectMappingLatestSpec.swift
@@ -10,7 +10,7 @@ class EffectMappingLatestSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
-        typealias EffectMapping = Harvester.EffectMapping<RequestEffectQueue, Never>
+        typealias EffectMapping = Harvester.EffectMapping<Void, RequestEffectQueue, Never>
 
         var inputs: PassthroughSubject<AuthInput, Never>!
         var harvester: Harvester!

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -10,7 +10,7 @@ class EffectMappingSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
-        typealias EffectMapping = Harvester.EffectMapping<BasicEffectQueue, Never>
+        typealias EffectMapping = Harvester.EffectMapping<Void, BasicEffectQueue, Never>
 
         var inputs: PassthroughSubject<AuthInput, Never>!
         var harvester: Harvester!

--- a/Tests/HarvestTests/ExternalInputSpec.swift
+++ b/Tests/HarvestTests/ExternalInputSpec.swift
@@ -10,7 +10,7 @@ class ExternalInputSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<AuthInput, AuthState>
-        typealias EffectMapping = Harvester.EffectMapping<RequestEffectQueue, Never>
+        typealias EffectMapping = Harvester.EffectMapping<Void, RequestEffectQueue, Never>
 
         var externalInputs: PassthroughSubject<ExternalAuthInput, Never>!   // NOTE: Using subset `ExternalAuthInput`
         var harvester: Harvester!

--- a/Tests/HarvestTests/StateFuncMappingSpec.swift
+++ b/Tests/HarvestTests/StateFuncMappingSpec.swift
@@ -11,7 +11,7 @@ class StateFuncMappingSpec: QuickSpec
         describe("State-change function mapping") {
 
             typealias Harvester = Harvest.Harvester<CountInput, CountState>
-            typealias EffectMapping = Harvester.EffectMapping<BasicEffectQueue, Never>
+            typealias EffectMapping = Harvester.EffectMapping<Void, BasicEffectQueue, Never>
 
             var inputs: PassthroughSubject<CountInput, Never>!
             var harvester: Harvester!

--- a/Tests/HarvestTests/TerminatingSpec.swift
+++ b/Tests/HarvestTests/TerminatingSpec.swift
@@ -9,7 +9,7 @@ class TerminatingSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<MyInput, MyState>
-        typealias EffectMapping = Harvester.EffectMapping<BasicEffectQueue, Never>
+        typealias EffectMapping = Harvester.EffectMapping<Void, BasicEffectQueue, Never>
 
         var inputs: PassthroughSubject<MyInput, Never>!
         var harvester: Harvester!

--- a/Tests/HarvestTests/TimerSubscriptionSpec.swift
+++ b/Tests/HarvestTests/TimerSubscriptionSpec.swift
@@ -11,7 +11,7 @@ class TimerSubscriptionSpec: QuickSpec
     override func spec()
     {
         typealias Harvester = Harvest.Harvester<TimerInput, Int>
-        typealias EffectMapping = Harvester.EffectMapping<BasicEffectQueue, EffectID>
+        typealias EffectMapping = Harvester.EffectMapping<Void, BasicEffectQueue, EffectID>
         typealias EffectID = String
 
         var inputs: PassthroughSubject<TimerInput, Never>!   // NOTE: Using subset `ExternalAuthInput`

--- a/Tests/HarvestTests/WorldSpec.swift
+++ b/Tests/HarvestTests/WorldSpec.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Combine
+import Harvest
+import Quick
+import Nimble
+import Thresher
+
+/// Tests for `World` injection.
+class WorldSpec: QuickSpec
+{
+    override func spec()
+    {
+        typealias Harvester = Harvest.Harvester<Input, State>
+        typealias EffectMapping = Harvester.EffectMapping<World, BasicEffectQueue, EffectID>
+        typealias EffectID = Never
+
+        var inputs: PassthroughSubject<Input, Never>!
+        var harvester: Harvester!
+        var lastReply: Reply<Input, State>?
+        var cancellables: Set<AnyCancellable>!
+        var testScheduler: TestScheduler!
+
+        beforeEach {
+            inputs = PassthroughSubject()
+            lastReply = nil
+            cancellables = []
+            testScheduler = TestScheduler()
+        }
+
+        describe("World") {
+
+            let mockedDate = Date(timeIntervalSince1970: 2019)
+
+            beforeEach {
+                let world = World(date: { mockedDate })
+
+                let mapping: EffectMapping = .makeInout { input, state in
+                    switch input {
+                    case .getDate:
+                        return Effect { world in
+                            Deferred { Just(world.date()) }
+                                .map(Input._didGetDate)
+                                .eraseToAnyPublisher()
+                        }
+
+                    case let ._didGetDate(date):
+                        state = date.timeIntervalSince1970
+                        return .empty
+                    }
+                }
+
+                harvester = Harvester(
+                    state: .init(),
+                    inputs: inputs,
+                    mapping: mapping,
+                    world: world,
+                    scheduler: testScheduler
+                )
+
+                harvester.replies
+                    .sink { reply in
+                        lastReply = reply
+                    }
+                    .store(in: &cancellables)
+            }
+
+            it("gets mocked date") {
+                expect(harvester.state) == 0
+                expect(lastReply).to(beNil())
+
+                inputs.send(.getDate)
+                testScheduler.advance()
+
+                expect(harvester.state) == mockedDate.timeIntervalSince1970
+                expect(lastReply?.fromState) == 0
+                expect(lastReply?.toState) == mockedDate.timeIntervalSince1970
+            }
+
+        }
+
+    }
+}
+
+private struct World
+{
+    let date: () -> Date
+}
+
+private enum Input
+{
+    case getDate
+    case _didGetDate(Date)
+}
+
+private typealias State = TimeInterval


### PR DESCRIPTION
This PR adds `World` type-parameter to let `Effect` own `(World) -> AnyPublisher<Input, Never>` (rather than plain publisher) so that Real-World-Dependencies e.g. `FileManager` or `Date()` can be injected during the `AnyPublisher` instantiation.

And using `contramapWorld` will help bridging different `World`s in different modules.

### Credit

This idea was first brought by @foolonhill and @stephencelis in the following discussion:
https://twitter.com/foolonhill/status/1189518919717081088

(If you find any issues in this impl, please let me know!)