### PR TITLE
Use `World` as argument of `EffectMapping`

### DIFF
--- a/Sources/Harvest/Mapping+Helper.swift
+++ b/Sources/Harvest/Mapping+Helper.swift
@@ -90,10 +90,10 @@ public func | <World, P: Publisher, Input, State, Queue, EffectID>(
 
 public func | <World, Input, State, Queue, EffectID>(
     mapping: Harvester<Input, State>.Mapping,
-    effect: Effect<World, Input, Queue, EffectID>
+    effect: Effect<Input, Queue, EffectID>
     ) -> Harvester<Input, State>.EffectMapping<World, Queue, EffectID>
 {
-    return .init { input, fromState in
+    return .init { input, fromState, world in
         if let toState = mapping.run(input, fromState) {
             return (toState, effect)
         }

--- a/Sources/HarvestOptics/Effect+Optics.swift
+++ b/Sources/HarvestOptics/Effect+Optics.swift
@@ -6,7 +6,7 @@ extension Harvest.Effect
     /// Transforms `Effect` from `ID` to `WholeID`.
     public func transform<WholeID>(
         id prism: Prism<WholeID, ID>
-    ) -> Effect<World, Input, Queue, WholeID>
+    ) -> Effect<Input, Queue, WholeID>
     {
         self.transformID(prism.inject, prism.tryGet)
     }

--- a/Sources/HarvestOptics/EffectMapping+Optics.swift
+++ b/Sources/HarvestOptics/EffectMapping+Optics.swift
@@ -8,9 +8,9 @@ extension Harvester.EffectMapping
         input inputTraversal: AffineTraversal<WholeInput, Input>
     ) -> Harvester<WholeInput, State>.EffectMapping<World, Queue, EffectID>
     {
-        return .init { wholeInput, state in
+        return .init { wholeInput, state, world in
             guard let partInput = inputTraversal.tryGet(wholeInput),
-                let (newState, effect) = self.run(partInput, state) else
+                let (newState, effect) = self.run(partInput, state, world) else
             {
                 return nil
             }
@@ -23,9 +23,9 @@ extension Harvester.EffectMapping
         state stateTraversal: AffineTraversal<WholeState, State>
     ) -> Harvester<Input, WholeState>.EffectMapping<World, Queue, EffectID>
     {
-        return .init { input, wholeState in
+        return .init { input, wholeState, world in
             guard let partState = stateTraversal.tryGet(wholeState),
-                let (newPartState, effect) = self.run(input, partState) else
+                let (newPartState, effect) = self.run(input, partState, world) else
             {
                 return nil
             }
@@ -41,8 +41,8 @@ extension Harvester.EffectMapping
         id prism: Prism<WholeEffectID, EffectID>
     ) -> Harvester<Input, State>.EffectMapping<World, Queue, WholeEffectID>
     {
-        return .init { input, state in
-            guard let (newState, effect) = self.run(input, state) else { return nil }
+        return .init { input, state, world in
+            guard let (newState, effect) = self.run(input, state, world) else { return nil }
             let effect2 = effect.transform(id: prism)
             return (newState, effect2)
         }

--- a/Sources/HarvestStore/Store.swift
+++ b/Sources/HarvestStore/Store.swift
@@ -17,7 +17,7 @@ public final class Store<Input, State>: ObservableObject
 
     public init<World, Queue: EffectQueueProtocol, EffectID>(
         state initialState: State,
-        effect initialEffect: Effect<World, Input, Queue, EffectID> = .empty,
+        effect initialEffect: Effect<Input, Queue, EffectID> = .empty,
         mapping: Harvester<Input, State>.EffectMapping<World, Queue, EffectID>,
         world: World
     )
@@ -104,10 +104,10 @@ private func lift<World, Input, State, Queue: EffectQueueProtocol, EffectID>(
     effectMapping: Harvester<Input, State>.EffectMapping<World, Queue, EffectID>
 ) -> Store<Input, State>.EffectMapping<World, Queue, EffectID>
 {
-    .init { input, state in
+    .init { input, state, world in
         switch input {
         case let .input(innerInput):
-            guard let (newState, effect) = effectMapping.run(innerInput, state) else {
+            guard let (newState, effect) = effectMapping.run(innerInput, state, world) else {
                 return nil
             }
             return (newState, effect.mapInput(Store<Input, State>.BindableInput.input))

--- a/Tests/HarvestTests/EffectMappingSpec.swift
+++ b/Tests/HarvestTests/EffectMappingSpec.swift
@@ -114,7 +114,7 @@ class EffectMappingSpec: QuickSpec
                         .delay(for: 1, scheduler: testScheduler)
                         .eraseToAnyPublisher()
 
-                let mapping: EffectMapping = .init { input, fromState in
+                let mapping: EffectMapping = .init { input, fromState, world in
                     switch (fromState, input) {
                         case (.loggedOut, .login):
                             return (.loggingIn, .init(loginOKPublisher))
@@ -196,7 +196,7 @@ class EffectMappingSpec: QuickSpec
                         .delay(for: 1, scheduler: testScheduler)
                         .eraseToAnyPublisher()
 
-                let mapping: EffectMapping = .makeInout { input, state in
+                let mapping: EffectMapping = .makeInout { input, state, world in
                     switch (state, input) {
                     case (.loggedOut, .login):
                         state = .loggingIn

--- a/Tests/HarvestTests/TimerSubscriptionSpec.swift
+++ b/Tests/HarvestTests/TimerSubscriptionSpec.swift
@@ -37,7 +37,7 @@ class TimerSubscriptionSpec: QuickSpec
                     .scan(0, { count, _ in count + 1 })
                     .map(TimerInput.tick)
 
-                let mapping: EffectMapping = .init { input, state in
+                let mapping: EffectMapping = .init { input, state, world in
                     switch input {
                     case .start:
                         return (state, Effect(timerPublisher, id: "timer"))

--- a/Tests/HarvestTests/WorldSpec.swift
+++ b/Tests/HarvestTests/WorldSpec.swift
@@ -34,14 +34,12 @@ class WorldSpec: QuickSpec
             beforeEach {
                 let world = World(date: { mockedDate })
 
-                let mapping: EffectMapping = .makeInout { input, state in
+                let mapping: EffectMapping = .makeInout { input, state, world in
                     switch input {
                     case .getDate:
-                        return Effect { world in
-                            Deferred { Just(world.date()) }
-                                .map(Input._didGetDate)
-                                .eraseToAnyPublisher()
-                        }
+                        return Deferred { Just(world.date()) }
+                            .map(Input._didGetDate)
+                            .toEffect()
 
                     case let ._didGetDate(date):
                         state = date.timeIntervalSince1970


### PR DESCRIPTION
This is a **breaking change** to use `World` inside `EffectMapping` rather than `Effect` to follow [ReaderT Design Pattern](https://www.fpcomplete.com/blog/2017/06/readert-design-pattern/) for more flexibility in dependency injection.

Additionally, `toEffect` / `toResultEffect` helper methods are added for easier `Effect` creation.