### PR TITLE
Add additional `|` operator for table-style mapping with `World` injection

### DIFF
--- a/Sources/Harvest/Mapping+Helper.swift
+++ b/Sources/Harvest/Mapping+Helper.swift
@@ -103,6 +103,21 @@ public func | <World, Input, State, Queue, EffectID>(
     }
 }
 
+public func | <World, Input, State, Queue, EffectID>(
+    mapping: Harvester<Input, State>.Mapping,
+    effect: @escaping (World) -> Effect<Input, Queue, EffectID>
+) -> Harvester<Input, State>.EffectMapping<World, Queue, EffectID>
+{
+    return .init { input, fromState, world in
+        if let toState = mapping.run(input, fromState) {
+            return (toState, effect(world))
+        }
+        else {
+            return nil
+        }
+    }
+}
+
 // MARK: Functions
 
 /// Helper for "any state" or "any input" mappings, e.g.


### PR DESCRIPTION
By #26 , table-style mapping becomes hard to inject `World`, so this PR adds extra `func |` to resolve the issue.

### Example

Previously:

```swift
        /// Sends `.loginOK` after delay, simulating async work during `.loggingIn`.
        let loginOKEffect = Effect<S>(queue: .request) { world in
            Just(StateDiagram.Input.loginOK)
                .delay(for: world.simulatedAsyncWorkDelay, scheduler: world.scheduler)
        }

        /// Sends `.logoutOK` after delay, simulating async work during `.loggingOut`.
        let logoutOKEffect = Effect<S>(queue: .request) { world in
            Just(StateDiagram.Input.logoutOK)
                .delay(for: world.simulatedAsyncWorkDelay, scheduler: world.scheduler)
        }

        let canForceLogout: (State) -> Bool = [.loggingIn, .loggedIn].contains

        let mappings: [StateDiagram.EffectMapping<S>] = [
            .login    | .loggedOut  => .loggingIn  | loginOKEffect,
            .loginOK  | .loggingIn  => .loggedIn   | .empty,
            .logout   | .loggedIn   => .loggingOut | logoutOKEffect,
            .logoutOK | .loggingOut => .loggedOut  | .empty,

            .forceLogout | canForceLogout => .loggingOut | logoutOKEffect
        ]
```

This PR will allow to define closure-style `Effect` as follows:

```swift
        /// Sends `.loginOK` after delay, simulating async work during `.loggingIn`.
        let loginOKEffect = { (world: World<S>) -> Effect in
            Just(StateDiagram.Input.loginOK)
                .delay(for: world.simulatedAsyncWorkDelay, scheduler: world.scheduler)
                .toEffect(queue: .request)
        }

        /// Sends `.logoutOK` after delay, simulating async work during `.loggingOut`.
        let logoutOKEffect = { (world: World<S>) -> Effect in
            Just(StateDiagram.Input.logoutOK)
                .delay(for: world.simulatedAsyncWorkDelay, scheduler: world.scheduler)
                .toEffect(queue: .request)
        }
```